### PR TITLE
feat: add tools, mutation guard, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ python -m opencti_mcp.server
 python -m opencti_mcp.server --enable-mutations
 ```
 
+Note:
+- `--enable-mutations` only affects this MCP server process.
+- It is a local safety guard to avoid exposing write-capable MCP servers by default.
+- It does not change permissions/capabilities on the remote OpenCTI/OEAV instance.
+- The target backend and token permissions must allow mutations, otherwise writes will still fail.
+
 5. Connect from your MCP client. Example config:
 
 ```json
@@ -57,6 +63,50 @@ python -m opencti_mcp.server --enable-mutations
         "OPENCTI_URL": "https://your-opencti",
         "OPENCTI_TOKEN": "<token>"
       }
+    }
+  }
+}
+```
+
+6. Deploy over HTTP when needed.
+
+Streamable HTTP server:
+
+```bash
+python -m opencti_mcp.server \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+Streamable HTTP MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "opencti-graphql-mcp": {
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
+
+SSE server:
+
+```bash
+python -m opencti_mcp.server \
+  --transport sse \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+SSE MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "opencti-graphql-mcp": {
+      "url": "http://127.0.0.1:8000/sse"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,43 +1,72 @@
 # XTM MCP Servers
 
-This repository hosts MCP (Model Context Protocol) servers related to Filigran's XTM Suite. More MCP servers to come!
+This repository hosts MCP (Model Context Protocol) servers for Filigran products.
 
-## Versioning strategy
-This repository follows Semantic Versioning (SemVer) with the version format `X.Y.Z`, where:
-- X (Major): Incremented for significant changes that introduce breaking changes or major new features that are not backward-compatible. 
-- Y (Minor): Incremented for new features or enhancements that are backward-compatible. Example: adding a new MCP server for one of the tools in the XTM suite
-- Z (Patch): Incremented for bug fixes or minor updates that are backward-compatible
-
-Versions are tagged in the format X.Y.Z (e.g., 1.0.0) in the GitHub repository.
-
-## Available servers
+At the moment it includes one server:
 
 | Server | Directory | Description |
-|--------|-----------|-------------|
-| OpenCTI GraphQL MCP | [`opencti_mcp/`](opencti_mcp/README.md) | Interact with an OpenCTI instance via its GraphQL API — introspect the schema, list types, run and validate queries. |
-
-See each server's README for configuration, usage, available tools, and MCP client setup.
+| --- | --- | --- |
+| OpenCTI GraphQL MCP | [`opencti_mcp/`](opencti_mcp/README.md) | Query and mutate OpenCTI from MCP clients (schema discovery, threat intel retrieval, brand posture workflows). |
 
 ## Requirements
 
 - Python 3.10+
-- pip and venv (or your preferred environment manager)
+- `pip` + `venv` (or an equivalent environment manager)
+- OpenCTI instance URL and API token
 
-## Quickstart
+## Quickstart (use the server)
 
-1. Create a virtual environment and install dependencies:
+1. Install dependencies:
 
 ```bash
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-2. Follow the server-specific README for configuration and usage (e.g. [`opencti_mcp/README.md`](opencti_mcp/README.md)).
+2. Configure credentials:
+
+```bash
+cp .env.example .env
+# edit .env and set:
+# OPENCTI_URL=https://your-opencti
+# OPENCTI_TOKEN=<your-token>
+```
+
+3. Run the MCP server (STDIO):
+
+```bash
+python -m opencti_mcp.server
+```
+
+4. Enable write tools only when needed:
+
+```bash
+python -m opencti_mcp.server --enable-mutations
+```
+
+5. Connect from your MCP client. Example config:
+
+```json
+{
+  "mcpServers": {
+    "opencti-graphql-mcp": {
+      "command": "python",
+      "args": ["-m", "opencti_mcp.server"],
+      "env": {
+        "OPENCTI_URL": "https://your-opencti",
+        "OPENCTI_TOKEN": "<token>"
+      }
+    }
+  }
+}
+```
+
+For full transport options and all tools, see [`opencti_mcp/README.md`](opencti_mcp/README.md).
 
 ## Development
 
-Install developer tooling (ruff, black, mypy):
+Install dev dependencies:
 
 ```bash
 pip install -r requirements-dev.txt
@@ -46,15 +75,31 @@ pip install -r requirements-dev.txt
 Run checks:
 
 ```bash
-# Lint
 ruff check .
-
-# Format
 black .
-
-# Type-check
 mypy .
-
-# Run tests
 pytest tests/
 ```
+
+## Contributing
+
+Contributions are welcome, including documentation improvements, bug fixes, and new tools.
+
+1. Create a feature branch from `main`.
+2. Implement changes and tests.
+3. Run `ruff`, `mypy`, and `pytest`.
+4. Open a PR with:
+  - clear problem statement
+  - implementation details
+  - test evidence
+
+Please read:
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## Versioning
+
+The project follows Semantic Versioning (`X.Y.Z`):
+- `X`: breaking changes
+- `Y`: backward-compatible features
+- `Z`: backward-compatible fixes

--- a/opencti_mcp/README.md
+++ b/opencti_mcp/README.md
@@ -124,6 +124,11 @@ To enable them, use:
 - `--enable-mutations`, or
 - `OPENCTI_ENABLE_MUTATIONS=true`
 
+Important:
+- This flag is a local safety guard on the MCP server only. It does not change anything on the target OpenCTI/OEAV instance.
+- Enabling mutations here only allows the MCP server to attempt write operations.
+- The backend instance and token permissions must still allow mutations; otherwise writes will still fail.
+
 Mutation tools:
 - `create_identity`
 - `create_label`

--- a/opencti_mcp/README.md
+++ b/opencti_mcp/README.md
@@ -153,8 +153,9 @@ Mutation tools:
 | `search_entities_by_name` | Search entities by name and intersect with available entity types |
 
 Notes:
-- `execute_graphql_query` keeps explicit operation prefixes (`query`, `mutation`, `subscription`).
-- If no operation prefix is provided, `execute_graphql_query` prepends `query`.
+- `execute_graphql_query` keeps explicit GraphQL document prefixes unchanged (`query`, `mutation`, `subscription`, `fragment`, etc.).
+- If no document prefix is provided, `execute_graphql_query` prepends `query`.
+- `mutation` operations submitted through `execute_graphql_query` follow the same mutation gate (`--enable-mutations` / `OPENCTI_ENABLE_MUTATIONS=true`) as dedicated write tools.
 - For write operations, use dedicated mutation tools.
 
 ### 2) Brand Posture Read Pack

--- a/opencti_mcp/README.md
+++ b/opencti_mcp/README.md
@@ -1,58 +1,81 @@
-# OpenCTI GraphQL MCP server
+# OpenCTI GraphQL MCP Server
 
-Tools and a server to interact with OpenCTI's GraphQL API via MCP.
+MCP server to interact with OpenCTI through GraphQL for:
+- schema discovery
+- threat data retrieval
+- brand posture workflows (read + publish back to OpenCTI)
 
-## Motivation
+## Requirements
 
-The goal of this MCP server is to provide an interface for interacting with an OpenCTI instance via its GraphQL API. To achieve this, we define a set of tools that help the agent introspect the schema, list available types and corresponding fields, and run or validate queries against your OpenCTI server. At this point, we focus on queries (i.e. reading the data). We plan to handle mutations in the near future.
+- Python 3.10+
+- OpenCTI URL + API token
 
-> For environment setup (venv, dependencies) and developer tooling, see the [root README](../README.md).
+Install dependencies from repository root:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
 ## Configuration
 
-Provide credentials via CLI flags or environment variables. `.env` is supported (see `.env.example`). Use the base URL of your OpenCTI; the server will automatically call the `/graphql` endpoint.
+You can pass credentials via CLI flags or environment variables (`.env` supported).
 
 ```bash
 cp .env.example .env
-# then edit .env to set OPENCTI_URL and OPENCTI_TOKEN
+# edit .env
+# OPENCTI_URL=https://your-opencti
+# OPENCTI_TOKEN=<token>
 ```
 
-- `OPENCTI_URL` – Base URL of your OpenCTI (e.g., `https://your-opencti`). The server appends `/graphql`.
-- `OPENCTI_TOKEN` – API token
+Variables:
+- `OPENCTI_URL`: OpenCTI base URL (the server appends `/graphql`)
+- `OPENCTI_TOKEN`: API token
+- `OPENCTI_ENABLE_MUTATIONS`: optional boolean (`true/false`, `1/0`, `yes/no`, `on/off`)
 
 ## Run
 
+### STDIO (default)
+
 ```bash
-# STDIO transport (default)
-python -m opencti_mcp.server --url "https://your-opencti/" --token "<token>"
+python -m opencti_mcp.server --url "https://your-opencti" --token "<token>"
+```
 
-# Explicitly select STDIO transport
-python -m opencti_mcp.server --transport stdio --url "https://your-opencti/" --token "<token>"
+### STDIO with mutations enabled
 
-# Streamable HTTP transport (recommended for remote / browser-based clients)
+```bash
 python -m opencti_mcp.server \
-  --transport streamable-http \
-  --host "127.0.0.1" \
-  --port 8000 \
-  --url "https://your-opencti/" \
-  --token "<token>"
-
-# SSE transport (legacy HTTP streaming)
-python -m opencti_mcp.server \
-  --transport sse \
-  --host "127.0.0.1" \
-  --port 8000 \
-  --url "https://your-opencti/" \
+  --enable-mutations \
+  --url "https://your-opencti" \
   --token "<token>"
 ```
 
-## MCP client configuration
+### Streamable HTTP
 
-Configure your MCP-enabled client to connect to this server. The JSON config differs depending on the transport.
+```bash
+python -m opencti_mcp.server \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --url "https://your-opencti" \
+  --token "<token>"
+```
 
-### STDIO (default)
+### SSE
 
-The client launches the server process automatically:
+```bash
+python -m opencti_mcp.server \
+  --transport sse \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --url "https://your-opencti" \
+  --token "<token>"
+```
+
+## MCP Client Config Examples
+
+### STDIO
 
 ```json
 {
@@ -61,7 +84,7 @@ The client launches the server process automatically:
       "command": "python",
       "args": ["-m", "opencti_mcp.server"],
       "env": {
-        "OPENCTI_URL": "https://your-opencti/",
+        "OPENCTI_URL": "https://your-opencti",
         "OPENCTI_TOKEN": "<token>"
       }
     }
@@ -69,42 +92,7 @@ The client launches the server process automatically:
 }
 ```
 
-Alternatively, you can omit `env` and pass flags via `args`, e.g.:
-
-```json
-{
-  "mcpServers": {
-    "opencti-graphql-mcp": {
-      "command": "python",
-      "args": [
-        "-m", "opencti_mcp.server",
-        "--url",
-        "https://your-opencti/",
-        "--token",
-        "<token>"
-      ]
-    }
-  }
-}
-```
-
-### SSE
-
-For SSE, the server must be started separately first (see the `--transport sse` command above). The client then connects to the running server:
-
-```json
-{
-  "mcpServers": {
-    "opencti-graphql-mcp": {
-      "url": "http://127.0.0.1:8000/sse"
-    }
-  }
-}
-```
-
 ### Streamable HTTP
-
-For streamable HTTP, the server must be started separately first (see the `--transport streamable-http` command above). The client then connects to the running server:
 
 ```json
 {
@@ -116,149 +104,120 @@ For streamable HTTP, the server must be started separately first (see the `--tra
 }
 ```
 
-## Testing the server
-
-After starting the server you can quickly verify each transport is working.
-
-### STDIO
-
-STDIO communicates over stdin/stdout pipes, so it cannot be tested with `curl`. You can pipe a JSON-RPC `initialize` message directly to the server process:
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
-  | python -m opencti_mcp.server --url "$OPENCTI_URL" --token "$OPENCTI_TOKEN"
-```
-
-A successful response is a JSON object containing `serverInfo` and `capabilities`.
-
-Alternatively, use the MCP Inspector:
-
-```bash
-npx @modelcontextprotocol/inspector
-```
-
 ### SSE
 
-With the server running on `--transport sse`, open the event stream with `curl`:
-
-```bash
-curl -N http://127.0.0.1:8000/sse
+```json
+{
+  "mcpServers": {
+    "opencti-graphql-mcp": {
+      "url": "http://127.0.0.1:8000/sse"
+    }
+  }
+}
 ```
 
-A successful connection immediately receives an `event: endpoint` line followed by a `data:` payload containing the message posting URL.
+## Mutation Safety
 
-### Streamable HTTP
+Mutation tools are exposed but blocked by default.
 
-With the server running on `--transport streamable-http`, send an `initialize` request:
+To enable them, use:
+- `--enable-mutations`, or
+- `OPENCTI_ENABLE_MUTATIONS=true`
 
-```bash
-curl -X POST http://127.0.0.1:8000/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
-```
+Mutation tools:
+- `create_identity`
+- `create_label`
+- `create_external_reference`
+- `create_grouping`
+- `create_report`
+- `add_note`
+- `create_relationship`
 
-A successful response is a JSON object containing `serverInfo` and `capabilities`.
+## Available Tools
 
-> **Note:** A plain `GET http://127.0.0.1:8000/mcp` returns `406 Not Acceptable` — this is expected. The streamable HTTP protocol requires specific `Accept` and `Content-Type` headers (see above).
+### 1) Schema and Query Helpers
 
-### Automated test suite
+| Tool | Purpose |
+| --- | --- |
+| `list_graphql_types` | List all GraphQL types from introspection |
+| `get_types_definitions` | Return field definitions for one or several types |
+| `get_types_definitions_from_schema` | Parse OpenCTI `/schema` SDL and return all type definitions |
+| `get_query_fields` | List GraphQL `Query` fields and arguments |
+| `validate_graphql_query` | Validate a query string against OpenCTI |
+| `execute_graphql_query` | Execute a GraphQL query string |
+| `get_stix_relationships_mapping` | Return available STIX relationship mappings |
+| `get_entity_names` | Return unique entity names extracted from relationship mapping |
+| `search_entities_by_name` | Search entities by name and intersect with available entity types |
 
-The project includes an automated test suite that validates all three transports end-to-end with a mocked GraphQL backend (no real OpenCTI instance needed):
+Notes:
+- `execute_graphql_query` is query-oriented (it prepends `query` if missing).
+- For write operations, use dedicated mutation tools.
+
+### 2) Brand Posture Read Pack
+
+| Tool | Purpose |
+| --- | --- |
+| `get_license_edition` | Detect if instance is `CE` or `EE` |
+| `list_identities` | List brand/supplier/subsidiary identities |
+| `read_identity` | Read a single identity by ID |
+| `list_stix_core_objects` | List reports, campaigns, threat actors, malware, tools, vulnerabilities, etc. |
+| `read_stix_core_object` | Read one STIX Core Object by ID |
+| `list_stix_core_relationships` | List relationships for pivoting and explainability |
+| `read_stix_core_relationship` | Read one STIX Core Relationship by ID |
+| `list_marking_definitions` | List markings (TLP, statements, etc.) |
+| `read_marking_definition` | Read one marking definition by ID |
+| `list_labels` | List labels |
+| `read_label` | Read one label by ID |
+
+### 3) Brand Posture Publish Pack (mutations enabled)
+
+| Tool | Purpose |
+| --- | --- |
+| `create_identity` | Create an identity (organization, individual, system, etc.) |
+| `create_label` | Create a label |
+| `create_external_reference` | Create source references (advisory, case URL, portal, etc.) |
+| `create_grouping` | Bundle objects used in a pulse |
+| `create_report` | Create a report |
+| `add_note` | Create a note attached to one or more objects |
+| `create_relationship` | Create a STIX core relationship |
+
+## Typical Brand Pulse Flow
+
+1. Detect platform capabilities:
+   - `get_license_edition`
+2. Scope identities:
+   - `list_identities`
+   - `read_identity`
+3. Collect threat context:
+   - `list_stix_core_objects` (reports, campaigns, threat actors, malware, tools, vulnerabilities)
+   - `list_stix_core_relationships`
+4. Prepare classification:
+   - `list_marking_definitions`
+   - `list_labels`
+5. Publish pulse:
+   - `create_external_reference`
+   - `create_label` (optional)
+   - `create_grouping` (optional)
+   - `add_note` and/or `create_report`
+   - `create_relationship`
+
+## Testing
+
+From repository root:
 
 ```bash
 pip install -r requirements-dev.txt
 pytest tests/
 ```
 
-## Available tools
+## Notes on OpenCTI Schema Access
 
-- `list_graphql_types`: Fetch and return the list of all GraphQL types.
-  - Inputs: none
-  - Outputs: JSON array of type names
+- GraphQL introspection queries (`/graphql`) are commonly disabled in production OpenCTI.
+- `/schema` endpoint is available from OpenCTI 6.8+.
 
-- `get_types_definitions`: Fetch and return the definition of one or more GraphQL types.
-  - Inputs:
-    - `type_name` (required): string or JSON array (or JSON-stringified array) of type names
-  - Outputs: JSON array of objects, each shaped as `{ "<TypeName>": [{ "name": string, "type": string|null, "kind": string|null }] }`
-  - Errors: returns a text error message if `type_name` missing or of wrong type
+This server supports both:
+- Introspection-based tools: `list_graphql_types`, `get_types_definitions`, `get_query_fields`
+- SDL-based tool: `get_types_definitions_from_schema`
 
-- `get_types_definitions_from_schema`: Return all type definitions using `/schema`.
-  - Inputs: none (reads `OPENCTI_URL` and `OPENCTI_TOKEN` from environment/.env)
-  - Outputs: JSON object mapping type name to type definition (fields, queries, relationship_type, related_types)
-
-- `execute_graphql_query`: Execute a GraphQL query and return the result.
-  - Inputs:
-    - `query` (required): GraphQL query string; if it does not start with `query`, the server will prepend `query`
-  - Outputs: JSON object `{ "success": true, "data": <GraphQL result> }` on success
-  - Errors: JSON object `{ "success": false, "error": string }` on failure
-
-- `validate_graphql_query`: Validate a GraphQL query without returning its result.
-  - Inputs:
-    - `query` (required): GraphQL query string; if it does not start with `query`, the server will prepend `query`
-  - Outputs: JSON object `{ "success": true, "error": "" }` if the query validates and executes successfully
-  - Errors: JSON object `{ "success": false, "error": string }` if validation/execution fails
-
-- `get_stix_relationships_mapping`: Get all possible STIX relationships between types and their available relationship types.
-  - Inputs:
-    - `type_name` (optional): filter to a specific type name; if provided, returns only related entities for this type
-  - Outputs:
-    - With filter: JSON object `{ "filtered_type": string, "relationships_mapping": string[] }`
-    - Without filter: JSON object `{ "relationships_mapping": { [typeName: string]: string[] } }`
-
-- `get_query_fields`: Get all field names from the GraphQL `Query` type.
-  - Inputs: none
-  - Outputs: JSON object `{ "query_fields": [{ "name": string, "args": [{ "name": string, "type": string|null }] }] }` (sorted by field name)
-  - Errors: text error if the `Query` type is not found
-
-- `get_entity_names`: Get all unique entity names from STIX relationships mapping.
-  - Inputs: none
-  - Outputs: JSON object `{ "entity_names": string[], "count": number }`
-
-- `search_entities_by_name`: Search for entities by name and intersect with available entity types.
-  - Inputs:
-    - `entity_name` (required): non-empty string to search for
-  - Outputs: JSON array of entity type strings present in both search results and available schema types
-  - Errors: text error if `entity_name` missing or empty
-
-### Example output
-
-Example output for `list_graphql_types`:
-
-```json
-[
-  "AttackPattern",
-  "Campaign",
-  "Note",
-  "User"
-]
-```
-
-## Example Workflow
-
-A typical agent workflow proceeds as follows:
-
-1. Receive a question from the user.
-2. Analyze (introspect) the GraphQL schema to identify which types are relevant to the user's question.
-3. Retrieve the definitions of these types to understand their relevant fields.
-4. Construct a GraphQL query that can answer the user's question.
-5. Execute the query and return the response to the user.
-
-## Notes on schema access
-
-- GraphQL introspection queries (via `/graphql`) is disabled by default in OpenCTI.
-- The `/schema` endpoint is available from OpenCTI 6.8.0 onwards and returns the schema SDL.
-- This MCP supports both approaches:
-  - Tools that rely on `/graphql` introspection (e.g., `get_types_definitions`). In this case, the introspection queries should be activated in your OpenCTI setup.
-  - Tools that load SDL from `/schema` and introspect locally (e.g., `get_types_definitions_from_schema`)
-
-The following tools rely on GraphQL **introspection queries**:
-
-- `list_graphql_types`
-- `get_types_definitions`
-- `get_query_fields`
-
-Even though they are enabled by default, most OpenCTI environments disable **introspection queries**. To use these tools, check your OpenCTI configuration as described in the [relevant documentation](https://docs.opencti.io/latest/deployment/configuration/?h=introspection#technical-customization). Namely, you need the environment variables:
-
-* `APP__GRAPHQL__PLAYGROUND__FORCE_DISABLED_INTROSPECTION` set to `true` (default)
-* `APP__GRAPHQL__PLAYGROUND__ENABLED` set to `true` (default)
+If introspection tools fail, verify OpenCTI configuration as described in official docs:
+https://docs.opencti.io/latest/deployment/configuration/?h=introspection#technical-customization

--- a/opencti_mcp/README.md
+++ b/opencti_mcp/README.md
@@ -129,6 +129,9 @@ Mutation tools:
 - `create_label`
 - `create_external_reference`
 - `create_grouping`
+- `create_pir`
+- `create_case_rfi`
+- `add_objects_to_case_rfi`
 - `create_report`
 - `add_note`
 - `create_relationship`
@@ -144,13 +147,14 @@ Mutation tools:
 | `get_types_definitions_from_schema` | Parse OpenCTI `/schema` SDL and return all type definitions |
 | `get_query_fields` | List GraphQL `Query` fields and arguments |
 | `validate_graphql_query` | Validate a query string against OpenCTI |
-| `execute_graphql_query` | Execute a GraphQL query string |
+| `execute_graphql_query` | Execute a GraphQL operation string (`query`, `mutation`, `subscription`) |
 | `get_stix_relationships_mapping` | Return available STIX relationship mappings |
 | `get_entity_names` | Return unique entity names extracted from relationship mapping |
 | `search_entities_by_name` | Search entities by name and intersect with available entity types |
 
 Notes:
-- `execute_graphql_query` is query-oriented (it prepends `query` if missing).
+- `execute_graphql_query` keeps explicit operation prefixes (`query`, `mutation`, `subscription`).
+- If no operation prefix is provided, `execute_graphql_query` prepends `query`.
 - For write operations, use dedicated mutation tools.
 
 ### 2) Brand Posture Read Pack
@@ -168,6 +172,10 @@ Notes:
 | `read_marking_definition` | Read one marking definition by ID |
 | `list_labels` | List labels |
 | `read_label` | Read one label by ID |
+| `list_pirs` | List priority intelligence requirements |
+| `read_pir` | Read one PIR by ID |
+| `list_case_rfis` | List case RFIs |
+| `read_case_rfi` | Read one case RFI by ID |
 
 ### 3) Brand Posture Publish Pack (mutations enabled)
 
@@ -177,6 +185,9 @@ Notes:
 | `create_label` | Create a label |
 | `create_external_reference` | Create source references (advisory, case URL, portal, etc.) |
 | `create_grouping` | Bundle objects used in a pulse |
+| `create_pir` | Create a PIR |
+| `create_case_rfi` | Create a case RFI |
+| `add_objects_to_case_rfi` | Attach one or more objects to a case RFI |
 | `create_report` | Create a report |
 | `add_note` | Create a note attached to one or more objects |
 | `create_relationship` | Create a STIX core relationship |

--- a/opencti_mcp/graphql_queries.py
+++ b/opencti_mcp/graphql_queries.py
@@ -46,3 +46,607 @@ query EntitySearchByName($term: String!) {
   }
 }
 """
+
+GET_LICENSE_EDITION_QUERY = """
+query GetLicenseEdition {
+  settings {
+    enterprise_edition
+  }
+}
+"""
+
+GET_LICENSE_EDITION_QUERY_CAMEL = """
+query GetLicenseEdition {
+  settings {
+    enterpriseEdition
+  }
+}
+"""
+
+IDENTITY_PROPERTIES = """
+id
+standard_id
+entity_type
+parent_types
+spec_version
+created_at
+updated_at
+identity_class
+name
+description
+contact_information
+x_opencti_aliases
+x_opencti_reliability
+... on Individual {
+  x_opencti_firstname
+  x_opencti_lastname
+}
+... on Organization {
+  x_opencti_organization_type
+  x_opencti_score
+}
+"""
+
+STIX_CORE_OBJECT_BRAND_PROPERTIES = """
+id
+standard_id
+entity_type
+parent_types
+spec_version
+created_at
+updated_at
+... on StixDomainObject {
+  revoked
+  confidence
+  created
+  modified
+}
+... on AttackPattern {
+  name
+  description
+  aliases
+}
+... on Campaign {
+  name
+  description
+  aliases
+  first_seen
+  last_seen
+  objective
+}
+... on CourseOfAction {
+  name
+  description
+}
+... on Grouping {
+  name
+  description
+  context
+}
+... on Identity {
+  identity_class
+  name
+  description
+  contact_information
+}
+... on Indicator {
+  name
+  description
+}
+... on Infrastructure {
+  name
+  description
+  aliases
+}
+... on IntrusionSet {
+  name
+  description
+  aliases
+}
+... on Malware {
+  name
+  description
+  aliases
+}
+... on Note {
+  attribute_abstract
+  content
+  note_types
+}
+... on Organization {
+  name
+  description
+  x_opencti_organization_type
+}
+... on Report {
+  name
+  description
+  report_types
+  published
+}
+... on ThreatActor {
+  name
+  description
+  aliases
+}
+... on Tool {
+  name
+  description
+  aliases
+}
+... on Vulnerability {
+  name
+  description
+}
+"""
+
+STIX_CORE_RELATIONSHIP_BRAND_PROPERTIES = """
+id
+standard_id
+entity_type
+relationship_type
+description
+start_time
+stop_time
+created_at
+updated_at
+confidence
+from {
+  ... on BasicObject {
+    id
+    entity_type
+    parent_types
+  }
+  ... on BasicRelationship {
+    id
+    entity_type
+    parent_types
+  }
+  ... on StixObject {
+    standard_id
+  }
+  ... on AttackPattern {
+    name
+  }
+  ... on Campaign {
+    name
+  }
+  ... on CourseOfAction {
+    name
+  }
+  ... on Grouping {
+    name
+  }
+  ... on Identity {
+    name
+  }
+  ... on Indicator {
+    name
+  }
+  ... on Infrastructure {
+    name
+  }
+  ... on IntrusionSet {
+    name
+  }
+  ... on Malware {
+    name
+  }
+  ... on Note {
+    attribute_abstract
+  }
+  ... on Report {
+    name
+  }
+  ... on ThreatActor {
+    name
+  }
+  ... on Tool {
+    name
+  }
+  ... on Vulnerability {
+    name
+  }
+}
+to {
+  ... on BasicObject {
+    id
+    entity_type
+    parent_types
+  }
+  ... on BasicRelationship {
+    id
+    entity_type
+    parent_types
+  }
+  ... on StixObject {
+    standard_id
+  }
+  ... on AttackPattern {
+    name
+  }
+  ... on Campaign {
+    name
+  }
+  ... on CourseOfAction {
+    name
+  }
+  ... on Grouping {
+    name
+  }
+  ... on Identity {
+    name
+  }
+  ... on Indicator {
+    name
+  }
+  ... on Infrastructure {
+    name
+  }
+  ... on IntrusionSet {
+    name
+  }
+  ... on Malware {
+    name
+  }
+  ... on Note {
+    attribute_abstract
+  }
+  ... on Report {
+    name
+  }
+  ... on ThreatActor {
+    name
+  }
+  ... on Tool {
+    name
+  }
+  ... on Vulnerability {
+    name
+  }
+}
+"""
+
+LIST_IDENTITIES_QUERY = f"""
+query ListIdentities(
+  $types: [String]
+  $search: String
+  $first: Int
+  $after: ID
+  $orderBy: IdentitiesOrdering
+  $orderMode: OrderingMode
+) {{
+  identities(
+    types: $types
+    search: $search
+    first: $first
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {{
+    edges {{
+      node {{
+        {IDENTITY_PROPERTIES}
+      }}
+    }}
+    pageInfo {{
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }}
+  }}
+}}
+"""
+
+READ_IDENTITY_QUERY = f"""
+query ReadIdentity($id: String!) {{
+  identity(id: $id) {{
+    {IDENTITY_PROPERTIES}
+  }}
+}}
+"""
+
+LIST_STIX_CORE_OBJECTS_QUERY = f"""
+query ListStixCoreObjects(
+  $types: [String]
+  $search: String
+  $first: Int
+  $after: ID
+  $orderBy: StixCoreObjectsOrdering
+  $orderMode: OrderingMode
+) {{
+  stixCoreObjects(
+    types: $types
+    search: $search
+    first: $first
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {{
+    edges {{
+      node {{
+        {STIX_CORE_OBJECT_BRAND_PROPERTIES}
+      }}
+    }}
+    pageInfo {{
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }}
+  }}
+}}
+"""
+
+READ_STIX_CORE_OBJECT_QUERY = f"""
+query ReadStixCoreObject($id: String!) {{
+  stixCoreObject(id: $id) {{
+    {STIX_CORE_OBJECT_BRAND_PROPERTIES}
+  }}
+}}
+"""
+
+LIST_STIX_CORE_RELATIONSHIPS_QUERY = f"""
+query ListStixCoreRelationships(
+  $fromOrToId: [String]
+  $fromId: [String]
+  $toId: [String]
+  $relationship_type: [String]
+  $search: String
+  $first: Int
+  $after: ID
+  $orderBy: StixCoreRelationshipsOrdering
+  $orderMode: OrderingMode
+) {{
+  stixCoreRelationships(
+    fromOrToId: $fromOrToId
+    fromId: $fromId
+    toId: $toId
+    relationship_type: $relationship_type
+    search: $search
+    first: $first
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {{
+    edges {{
+      node {{
+        {STIX_CORE_RELATIONSHIP_BRAND_PROPERTIES}
+      }}
+    }}
+    pageInfo {{
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }}
+  }}
+}}
+"""
+
+READ_STIX_CORE_RELATIONSHIP_QUERY = f"""
+query ReadStixCoreRelationship($id: String!) {{
+  stixCoreRelationship(id: $id) {{
+    {STIX_CORE_RELATIONSHIP_BRAND_PROPERTIES}
+  }}
+}}
+"""
+
+LIST_MARKING_DEFINITIONS_QUERY = """
+query ListMarkingDefinitions(
+  $first: Int
+  $after: ID
+  $orderBy: MarkingDefinitionsOrdering
+  $orderMode: OrderingMode
+) {
+  markingDefinitions(
+    first: $first
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {
+    edges {
+      node {
+        id
+        standard_id
+        entity_type
+        parent_types
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+        created
+        modified
+        created_at
+        updated_at
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }
+  }
+}
+"""
+
+READ_MARKING_DEFINITION_QUERY = """
+query ReadMarkingDefinition($id: String!) {
+  markingDefinition(id: $id) {
+    id
+    standard_id
+    entity_type
+    parent_types
+    definition_type
+    definition
+    x_opencti_order
+    x_opencti_color
+    created
+    modified
+    created_at
+    updated_at
+  }
+}
+"""
+
+LIST_LABELS_QUERY = """
+query ListLabels(
+  $search: String
+  $first: Int
+  $after: ID
+  $orderBy: LabelsOrdering
+  $orderMode: OrderingMode
+) {
+  labels(
+    search: $search
+    first: $first
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {
+    edges {
+      node {
+        id
+        value
+        color
+        created_at
+        updated_at
+        standard_id
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }
+  }
+}
+"""
+
+READ_LABEL_QUERY = """
+query ReadLabel($id: String!) {
+  label(id: $id) {
+    id
+    value
+    color
+    created_at
+    updated_at
+    standard_id
+  }
+}
+"""
+
+CREATE_IDENTITY_MUTATION = """
+mutation CreateIdentity($input: IdentityAddInput!) {
+  identityAdd(input: $input) {
+    id
+    standard_id
+    entity_type
+    parent_types
+    identity_class
+    name
+    description
+  }
+}
+"""
+
+CREATE_ORGANIZATION_MUTATION = """
+mutation CreateOrganization($input: OrganizationAddInput!) {
+  organizationAdd(input: $input) {
+    id
+    standard_id
+    entity_type
+    parent_types
+    identity_class
+    name
+    description
+    x_opencti_organization_type
+  }
+}
+"""
+
+CREATE_GROUPING_MUTATION = """
+mutation CreateGrouping($input: GroupingAddInput!) {
+  groupingAdd(input: $input) {
+    id
+    standard_id
+    entity_type
+    parent_types
+    name
+    context
+    description
+  }
+}
+"""
+
+CREATE_EXTERNAL_REFERENCE_MUTATION = """
+mutation CreateExternalReference($input: ExternalReferenceAddInput!) {
+  externalReferenceAdd(input: $input) {
+    id
+    standard_id
+    entity_type
+    source_name
+    description
+    url
+    external_id
+  }
+}
+"""
+
+CREATE_LABEL_MUTATION = """
+mutation CreateLabel($input: LabelAddInput!) {
+  labelAdd(input: $input) {
+    id
+    value
+    color
+    created_at
+    updated_at
+    standard_id
+  }
+}
+"""
+
+CREATE_REPORT_MUTATION = """
+mutation CreateReport($input: ReportAddInput!) {
+  reportAdd(input: $input) {
+    id
+    standard_id
+    name
+    description
+    report_types
+    published
+    confidence
+  }
+}
+"""
+
+ADD_NOTE_MUTATION = """
+mutation AddNote($input: NoteAddInput!) {
+  noteAdd(input: $input) {
+    id
+    standard_id
+    attribute_abstract
+    content
+    note_types
+    confidence
+  }
+}
+"""
+
+CREATE_RELATIONSHIP_MUTATION = """
+mutation CreateRelationship($input: StixCoreRelationshipAddInput!) {
+  stixCoreRelationshipAdd(input: $input) {
+    id
+    standard_id
+    relationship_type
+  }
+}
+"""

--- a/opencti_mcp/server.py
+++ b/opencti_mcp/server.py
@@ -15,6 +15,12 @@ from opencti_mcp.tools import (
     add_note as add_note_tool,
 )
 from opencti_mcp.tools import (
+    add_objects_to_case_rfi as add_objects_to_case_rfi_tool,
+)
+from opencti_mcp.tools import (
+    create_case_rfi as create_case_rfi_tool,
+)
+from opencti_mcp.tools import (
     create_external_reference as create_external_reference_tool,
 )
 from opencti_mcp.tools import (
@@ -25,6 +31,9 @@ from opencti_mcp.tools import (
 )
 from opencti_mcp.tools import (
     create_label as create_label_tool,
+)
+from opencti_mcp.tools import (
+    create_pir as create_pir_tool,
 )
 from opencti_mcp.tools import (
     create_relationship as create_relationship_tool,
@@ -54,6 +63,9 @@ from opencti_mcp.tools import (
     get_types_definitions_from_schema as get_types_definitions_from_schema_tool,
 )
 from opencti_mcp.tools import (
+    list_case_rfis as list_case_rfis_tool,
+)
+from opencti_mcp.tools import (
     list_graphql_types as list_graphql_types_tool,
 )
 from opencti_mcp.tools import (
@@ -66,10 +78,16 @@ from opencti_mcp.tools import (
     list_marking_definitions as list_marking_definitions_tool,
 )
 from opencti_mcp.tools import (
+    list_pirs as list_pirs_tool,
+)
+from opencti_mcp.tools import (
     list_stix_core_objects as list_stix_core_objects_tool,
 )
 from opencti_mcp.tools import (
     list_stix_core_relationships as list_stix_core_relationships_tool,
+)
+from opencti_mcp.tools import (
+    read_case_rfi as read_case_rfi_tool,
 )
 from opencti_mcp.tools import (
     read_identity as read_identity_tool,
@@ -79,6 +97,9 @@ from opencti_mcp.tools import (
 )
 from opencti_mcp.tools import (
     read_marking_definition as read_marking_definition_tool,
+)
+from opencti_mcp.tools import (
+    read_pir as read_pir_tool,
 )
 from opencti_mcp.tools import (
     read_stix_core_object as read_stix_core_object_tool,
@@ -149,7 +170,8 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Enable write tools (create_report, add_note, create_relationship, "
-            "create_identity, create_grouping, create_external_reference, create_label). "
+            "create_identity, create_grouping, create_external_reference, create_label, "
+            "create_pir, create_case_rfi, add_objects_to_case_rfi). "
             "Mutations are disabled by default."
         ),
     )
@@ -454,6 +476,71 @@ async def read_label(
 
 
 @mcp_server.tool()
+async def list_pirs(
+    ctx: Context,
+    search: str | None = None,
+    first: int = 50,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List PIRs with optional filters."""
+    arguments: dict[str, Any] = {"first": first}
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_pirs_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_pir(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one PIR by OpenCTI ID."""
+    return await _with_session(ctx, read_pir_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def list_case_rfis(
+    ctx: Context,
+    search: str | None = None,
+    first: int = 50,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+    pir_id: str | None = None,
+) -> list[mcp_types.TextContent]:
+    """List case RFIs with optional filters."""
+    arguments: dict[str, Any] = {"first": first}
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    if pir_id is not None:
+        arguments["pir_id"] = pir_id
+    return await _with_session(ctx, list_case_rfis_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_case_rfi(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one case RFI by OpenCTI ID."""
+    return await _with_session(ctx, read_case_rfi_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
 async def create_identity(
     ctx: Context,
     name: str,
@@ -565,6 +652,100 @@ async def create_label(
     if color is not None:
         arguments["color"] = color
     return await _with_session(ctx, create_label_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_pir(
+    ctx: Context,
+    name: str,
+    description: str | None = None,
+    content: str | None = None,
+    priority: str | None = None,
+    severity: str | None = None,
+    confidence: int = 80,
+    object_marking: list[str] | None = None,
+    object_label: list[str] | None = None,
+    external_references: list[str] | None = None,
+    objects: list[str] | None = None,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create a PIR in OpenCTI."""
+    arguments: dict[str, Any] = {
+        "name": name,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description is not None:
+        arguments["description"] = description
+    if content is not None:
+        arguments["content"] = content
+    if priority is not None:
+        arguments["priority"] = priority
+    if severity is not None:
+        arguments["severity"] = severity
+    if object_marking is not None:
+        arguments["object_marking"] = object_marking
+    if object_label is not None:
+        arguments["object_label"] = object_label
+    if external_references is not None:
+        arguments["external_references"] = external_references
+    if objects is not None:
+        arguments["objects"] = objects
+    return await _with_session(ctx, create_pir_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_case_rfi(
+    ctx: Context,
+    name: str,
+    description: str | None = None,
+    content: str | None = None,
+    severity: str | None = None,
+    pir_id: str | None = None,
+    confidence: int = 80,
+    object_marking: list[str] | None = None,
+    object_label: list[str] | None = None,
+    external_references: list[str] | None = None,
+    objects: list[str] | None = None,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create a case RFI in OpenCTI."""
+    arguments: dict[str, Any] = {
+        "name": name,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description is not None:
+        arguments["description"] = description
+    if content is not None:
+        arguments["content"] = content
+    if severity is not None:
+        arguments["severity"] = severity
+    if pir_id is not None:
+        arguments["pir_id"] = pir_id
+    if object_marking is not None:
+        arguments["object_marking"] = object_marking
+    if object_label is not None:
+        arguments["object_label"] = object_label
+    if external_references is not None:
+        arguments["external_references"] = external_references
+    if objects is not None:
+        arguments["objects"] = objects
+    return await _with_session(ctx, create_case_rfi_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def add_objects_to_case_rfi(
+    ctx: Context,
+    id: str,  # noqa: A002
+    object_ids: list[str],
+) -> list[mcp_types.TextContent]:
+    """Add one or more objects to an existing case RFI."""
+    return await _with_session(
+        ctx,
+        add_objects_to_case_rfi_tool.handle,
+        {"id": id, "object_ids": object_ids},
+    )
 
 
 @mcp_server.tool()

--- a/opencti_mcp/server.py
+++ b/opencti_mcp/server.py
@@ -12,10 +12,34 @@ from mcp import types as mcp_types
 from mcp.server.fastmcp import Context, FastMCP
 
 from opencti_mcp.tools import (
+    add_note as add_note_tool,
+)
+from opencti_mcp.tools import (
+    create_external_reference as create_external_reference_tool,
+)
+from opencti_mcp.tools import (
+    create_grouping as create_grouping_tool,
+)
+from opencti_mcp.tools import (
+    create_identity as create_identity_tool,
+)
+from opencti_mcp.tools import (
+    create_label as create_label_tool,
+)
+from opencti_mcp.tools import (
+    create_relationship as create_relationship_tool,
+)
+from opencti_mcp.tools import (
+    create_report as create_report_tool,
+)
+from opencti_mcp.tools import (
     execute_graphql_query as execute_graphql_query_tool,
 )
 from opencti_mcp.tools import (
     get_entity_names as get_entity_names_tool,
+)
+from opencti_mcp.tools import (
+    get_license_edition as get_license_edition_tool,
 )
 from opencti_mcp.tools import (
     get_query_fields as get_query_fields_tool,
@@ -33,6 +57,36 @@ from opencti_mcp.tools import (
     list_graphql_types as list_graphql_types_tool,
 )
 from opencti_mcp.tools import (
+    list_identities as list_identities_tool,
+)
+from opencti_mcp.tools import (
+    list_labels as list_labels_tool,
+)
+from opencti_mcp.tools import (
+    list_marking_definitions as list_marking_definitions_tool,
+)
+from opencti_mcp.tools import (
+    list_stix_core_objects as list_stix_core_objects_tool,
+)
+from opencti_mcp.tools import (
+    list_stix_core_relationships as list_stix_core_relationships_tool,
+)
+from opencti_mcp.tools import (
+    read_identity as read_identity_tool,
+)
+from opencti_mcp.tools import (
+    read_label as read_label_tool,
+)
+from opencti_mcp.tools import (
+    read_marking_definition as read_marking_definition_tool,
+)
+from opencti_mcp.tools import (
+    read_stix_core_object as read_stix_core_object_tool,
+)
+from opencti_mcp.tools import (
+    read_stix_core_relationship as read_stix_core_relationship_tool,
+)
+from opencti_mcp.tools import (
     search_entities_by_name as search_entities_by_name_tool,
 )
 from opencti_mcp.tools import (
@@ -41,6 +95,7 @@ from opencti_mcp.tools import (
 from opencti_mcp.utils.common import read_opencti_env
 
 logger = getLogger(__name__)
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 def configure_logging() -> None:
@@ -87,6 +142,16 @@ def parse_args() -> argparse.Namespace:
         dest="json_response",
         action="store_true",
         help="Return JSON HTTP responses instead of SSE (streamable-http only)",
+    )
+    parser.add_argument(
+        "--enable-mutations",
+        dest="enable_mutations",
+        action="store_true",
+        help=(
+            "Enable write tools (create_report, add_note, create_relationship, "
+            "create_identity, create_grouping, create_external_reference, create_label). "
+            "Mutations are disabled by default."
+        ),
     )
     return parser.parse_args()
 
@@ -211,6 +276,298 @@ async def get_entity_names(
 
 
 @mcp_server.tool()
+async def get_license_edition(
+    ctx: Context,
+) -> list[mcp_types.TextContent]:
+    """Detect whether OpenCTI runs Community Edition (CE) or Enterprise Edition (EE)."""
+    return await _with_session(ctx, get_license_edition_tool.handle, {})
+
+
+@mcp_server.tool()
+async def list_identities(
+    ctx: Context,
+    types: list[str] | None = None,
+    search: str | None = None,
+    first: int = 50,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List identities (brand, suppliers, subsidiaries) with optional filters."""
+    arguments: dict[str, Any] = {"first": first}
+    if types is not None:
+        arguments["types"] = types
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_identities_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_identity(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one identity by OpenCTI ID."""
+    return await _with_session(ctx, read_identity_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def list_stix_core_objects(
+    ctx: Context,
+    types: list[str] | None = None,
+    search: str | None = None,
+    first: int = 50,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List STIX Core Objects across reports, campaigns, threats, TTPs and vulnerabilities."""
+    arguments: dict[str, Any] = {"first": first}
+    if types is not None:
+        arguments["types"] = types
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_stix_core_objects_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_stix_core_object(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one STIX Core Object by OpenCTI ID."""
+    return await _with_session(ctx, read_stix_core_object_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def list_stix_core_relationships(
+    ctx: Context,
+    from_or_to_ids: list[str] | None = None,
+    from_ids: list[str] | None = None,
+    to_ids: list[str] | None = None,
+    relationship_types: list[str] | None = None,
+    search: str | None = None,
+    first: int = 100,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List STIX Core Relationships for pivoting and impact explanations."""
+    arguments: dict[str, Any] = {"first": first}
+    if from_or_to_ids is not None:
+        arguments["from_or_to_ids"] = from_or_to_ids
+    if from_ids is not None:
+        arguments["from_ids"] = from_ids
+    if to_ids is not None:
+        arguments["to_ids"] = to_ids
+    if relationship_types is not None:
+        arguments["relationship_types"] = relationship_types
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_stix_core_relationships_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_stix_core_relationship(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one STIX Core Relationship by OpenCTI ID."""
+    return await _with_session(ctx, read_stix_core_relationship_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def list_marking_definitions(
+    ctx: Context,
+    first: int = 100,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List marking definitions (e.g. TLP) available in the instance."""
+    arguments: dict[str, Any] = {"first": first}
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_marking_definitions_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_marking_definition(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one marking definition by OpenCTI ID."""
+    return await _with_session(ctx, read_marking_definition_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def list_labels(
+    ctx: Context,
+    search: str | None = None,
+    first: int = 100,
+    after: str | None = None,
+    orderBy: str | None = None,  # noqa: N803
+    orderMode: str | None = None,  # noqa: N803
+) -> list[mcp_types.TextContent]:
+    """List labels with optional search."""
+    arguments: dict[str, Any] = {"first": first}
+    if search is not None:
+        arguments["search"] = search
+    if after is not None:
+        arguments["after"] = after
+    if orderBy is not None:
+        arguments["orderBy"] = orderBy
+    if orderMode is not None:
+        arguments["orderMode"] = orderMode
+    return await _with_session(ctx, list_labels_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def read_label(
+    ctx: Context,
+    id: str,  # noqa: A002
+) -> list[mcp_types.TextContent]:
+    """Read one label by OpenCTI ID."""
+    return await _with_session(ctx, read_label_tool.handle, {"id": id})
+
+
+@mcp_server.tool()
+async def create_identity(
+    ctx: Context,
+    name: str,
+    type: str = "Organization",  # noqa: A002
+    description: str | None = None,
+    contact_information: str | None = None,
+    confidence: int = 80,
+    object_marking: list[str] | None = None,
+    object_label: list[str] | None = None,
+    external_references: list[str] | None = None,
+    x_opencti_organization_type: str | None = None,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create an identity (organization, individual, system, etc.)."""
+    arguments: dict[str, Any] = {
+        "name": name,
+        "type": type,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description is not None:
+        arguments["description"] = description
+    if contact_information is not None:
+        arguments["contact_information"] = contact_information
+    if object_marking is not None:
+        arguments["object_marking"] = object_marking
+    if object_label is not None:
+        arguments["object_label"] = object_label
+    if external_references is not None:
+        arguments["external_references"] = external_references
+    if x_opencti_organization_type is not None:
+        arguments["x_opencti_organization_type"] = x_opencti_organization_type
+    return await _with_session(ctx, create_identity_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_grouping(
+    ctx: Context,
+    name: str,
+    context: str,
+    description: str | None = None,
+    content: str | None = None,
+    objects: list[str] | None = None,
+    object_marking: list[str] | None = None,
+    object_label: list[str] | None = None,
+    external_references: list[str] | None = None,
+    confidence: int = 80,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create a grouping to bundle all objects used in a brand pulse."""
+    arguments: dict[str, Any] = {
+        "name": name,
+        "context": context,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description is not None:
+        arguments["description"] = description
+    if content is not None:
+        arguments["content"] = content
+    if objects is not None:
+        arguments["objects"] = objects
+    if object_marking is not None:
+        arguments["object_marking"] = object_marking
+    if object_label is not None:
+        arguments["object_label"] = object_label
+    if external_references is not None:
+        arguments["external_references"] = external_references
+    return await _with_session(ctx, create_grouping_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_external_reference(
+    ctx: Context,
+    source_name: str | None = None,
+    url: str | None = None,
+    description: str | None = None,
+    external_id: str | None = None,
+    x_opencti_stix_ids: list[str] | None = None,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create an external reference (vendor advisory, takedown portal, case URL, etc.)."""
+    arguments: dict[str, Any] = {"update": update}
+    if source_name is not None:
+        arguments["source_name"] = source_name
+    if url is not None:
+        arguments["url"] = url
+    if description is not None:
+        arguments["description"] = description
+    if external_id is not None:
+        arguments["external_id"] = external_id
+    if x_opencti_stix_ids is not None:
+        arguments["x_opencti_stix_ids"] = x_opencti_stix_ids
+    return await _with_session(ctx, create_external_reference_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_label(
+    ctx: Context,
+    value: str,
+    color: str | None = None,
+    update: bool = False,
+) -> list[mcp_types.TextContent]:
+    """Create a label for internal taxonomy/tagging."""
+    arguments: dict[str, Any] = {
+        "value": value,
+        "update": update,
+    }
+    if color is not None:
+        arguments["color"] = color
+    return await _with_session(ctx, create_label_tool.handle, arguments)
+
+
+@mcp_server.tool()
 async def search_entities_by_name(
     ctx: Context,
     entity_name: str,
@@ -220,6 +577,75 @@ async def search_entities_by_name(
         ctx,
         search_entities_by_name_tool.handle,
         {"entity_name": entity_name},
+    )
+
+
+@mcp_server.tool()
+async def create_report(
+    ctx: Context,
+    name: str,
+    description: str,
+    report_types: list[str] | None = None,
+    published: str | None = None,
+    confidence: int = 80,
+    objects: list[str] | None = None,
+    labels: list[str] | None = None,
+) -> list[mcp_types.TextContent]:
+    """Create a report in OpenCTI."""
+    arguments: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "confidence": confidence,
+    }
+    if report_types is not None:
+        arguments["report_types"] = report_types
+    if published is not None:
+        arguments["published"] = published
+    if objects is not None:
+        arguments["objects"] = objects
+    if labels is not None:
+        arguments["labels"] = labels
+    return await _with_session(ctx, create_report_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def add_note(
+    ctx: Context,
+    content: str,
+    objects: list[str],
+    attribute_abstract: str | None = None,
+    note_types: list[str] | None = None,
+    confidence: int = 80,
+) -> list[mcp_types.TextContent]:
+    """Add a note to one or more entities in OpenCTI."""
+    arguments: dict[str, Any] = {
+        "content": content,
+        "objects": objects,
+        "confidence": confidence,
+    }
+    if attribute_abstract is not None:
+        arguments["attribute_abstract"] = attribute_abstract
+    if note_types is not None:
+        arguments["note_types"] = note_types
+    return await _with_session(ctx, add_note_tool.handle, arguments)
+
+
+@mcp_server.tool()
+async def create_relationship(
+    ctx: Context,
+    fromId: str,  # noqa: N803
+    toId: str,  # noqa: N803
+    relationship_type: str,
+) -> list[mcp_types.TextContent]:
+    """Create a relationship between two entities in OpenCTI."""
+    return await _with_session(
+        ctx,
+        create_relationship_tool.handle,
+        {
+            "fromId": fromId,
+            "toId": toId,
+            "relationship_type": relationship_type,
+        },
     )
 
 
@@ -239,6 +665,15 @@ def main() -> None:
     # Ensure downstream helpers and tools see the resolved values via environment variables.
     os.environ["OPENCTI_URL"] = url
     os.environ["OPENCTI_TOKEN"] = token
+
+    mutations_enabled = args.enable_mutations or (
+        os.getenv("OPENCTI_ENABLE_MUTATIONS", "").strip().lower() in _TRUE_ENV_VALUES
+    )
+    os.environ["OPENCTI_ENABLE_MUTATIONS"] = "true" if mutations_enabled else "false"
+    if mutations_enabled:
+        logger.info("Mutation tools are enabled.")
+    else:
+        logger.info("Mutation tools are disabled. Use --enable-mutations to enable writes.")
 
     # Configure transport settings – FastMCP.run() reads from self.settings
     mcp_server.settings.host = args.host

--- a/opencti_mcp/tools/add_note.py
+++ b/opencti_mcp/tools/add_note.py
@@ -1,10 +1,17 @@
-import json
 from typing import Any
 
 from gql import gql
 from mcp import types as mcp_types
 
 from opencti_mcp.graphql_queries import ADD_NOTE_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
 from opencti_mcp.utils.mutations import mutations_enabled
 
 _MUTATIONS_DISABLED_MESSAGE = (
@@ -13,90 +20,42 @@ _MUTATIONS_DISABLED_MESSAGE = (
 )
 
 
-def _error_response(message: str) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": False, "error": message}, indent=2),
-        )
-    ]
-
-
-def _success_response(data: Any) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": True, "data": data}, indent=2),
-        )
-    ]
-
-
-def _normalize_string_list(
-    value: Any, field_name: str, *, required: bool = False
-) -> tuple[list[str] | None, str | None]:
-    if value is None:
-        if required:
-            return None, f"{field_name} is required"
-        return None, None
-
-    if not isinstance(value, list):
-        return None, f"{field_name} must be a list of strings"
-
-    normalized: list[str] = []
-    for item in value:
-        if not isinstance(item, str):
-            return None, f"{field_name} must only contain strings"
-        cleaned = item.strip()
-        if not cleaned:
-            return None, f"{field_name} cannot contain empty strings"
-        normalized.append(cleaned)
-
-    if required and not normalized:
-        return None, f"{field_name} cannot be empty"
-
-    return normalized, None
-
-
-def _normalize_confidence(value: Any) -> tuple[int | None, str | None]:
-    if value is None:
-        return 80, None
-    if isinstance(value, bool) or not isinstance(value, int):
-        return None, "confidence must be an integer between 0 and 100"
-    if value < 0 or value > 100:
-        return None, "confidence must be an integer between 0 and 100"
-    return value, None
-
-
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
     if not mutations_enabled():
-        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
 
-    if not isinstance(arguments, dict):
-        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
 
-    content_raw = arguments.get("content")
-    if not isinstance(content_raw, str) or not content_raw.strip():
-        return _error_response("content is required and must be a non-empty string")
-    content = content_raw.strip()
+    content, content_error = normalize_non_empty_string(
+        arguments.get("content"),
+        "content",
+        required=True,
+    )
+    if content_error:
+        return error_response(content_error)
+    assert content is not None
 
-    objects, objects_error = _normalize_string_list(
+    objects, objects_error = normalize_string_list(
         arguments.get("objects"),
         "objects",
         required=True,
     )
     if objects_error:
-        return _error_response(objects_error)
-    assert objects is not None  # appease type checker after required=True
+        return error_response(objects_error)
+    assert objects is not None
 
-    note_types, note_types_error = _normalize_string_list(arguments.get("note_types"), "note_types")
+    note_types, note_types_error = normalize_string_list(arguments.get("note_types"), "note_types")
     if note_types_error:
-        return _error_response(note_types_error)
+        return error_response(note_types_error)
     if note_types is None:
         note_types = ["external"]
 
-    confidence, confidence_error = _normalize_confidence(arguments.get("confidence"))
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
     if confidence_error:
-        return _error_response(confidence_error)
+        return error_response(confidence_error)
+    assert confidence is not None
 
     input_payload: dict[str, Any] = {
         "content": content,
@@ -105,13 +64,17 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
         "confidence": confidence,
     }
 
-    attribute_abstract = arguments.get("attribute_abstract")
-    if attribute_abstract is not None:
-        if not isinstance(attribute_abstract, str) or not attribute_abstract.strip():
-            return _error_response(
-                "attribute_abstract must be a non-empty string when provided"
-            )
-        input_payload["attribute_abstract"] = attribute_abstract.strip()
+    attribute_abstract_raw = arguments.get("attribute_abstract")
+    attribute_abstract, attribute_abstract_error = normalize_non_empty_string(
+        attribute_abstract_raw,
+        "attribute_abstract",
+    )
+    if attribute_abstract_error:
+        return error_response(attribute_abstract_error)
+    if attribute_abstract_raw is not None and attribute_abstract is None:
+        return error_response("attribute_abstract must be a non-empty string when provided")
+    if attribute_abstract:
+        input_payload["attribute_abstract"] = attribute_abstract
 
     try:
         result = await session.execute(
@@ -119,7 +82,7 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
             variable_values={"input": input_payload},
         )
     except Exception as error:  # noqa: BLE001
-        return _error_response(str(error))
+        return error_response(str(error))
 
     note_data = result.get("noteAdd", {})
-    return _success_response(note_data)
+    return success_response(note_data)

--- a/opencti_mcp/tools/add_note.py
+++ b/opencti_mcp/tools/add_note.py
@@ -1,0 +1,125 @@
+import json
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import ADD_NOTE_MUTATION
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+def _error_response(message: str) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": False, "error": message}, indent=2),
+        )
+    ]
+
+
+def _success_response(data: Any) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": True, "data": data}, indent=2),
+        )
+    ]
+
+
+def _normalize_string_list(
+    value: Any, field_name: str, *, required: bool = False
+) -> tuple[list[str] | None, str | None]:
+    if value is None:
+        if required:
+            return None, f"{field_name} is required"
+        return None, None
+
+    if not isinstance(value, list):
+        return None, f"{field_name} must be a list of strings"
+
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None, f"{field_name} must only contain strings"
+        cleaned = item.strip()
+        if not cleaned:
+            return None, f"{field_name} cannot contain empty strings"
+        normalized.append(cleaned)
+
+    if required and not normalized:
+        return None, f"{field_name} cannot be empty"
+
+    return normalized, None
+
+
+def _normalize_confidence(value: Any) -> tuple[int | None, str | None]:
+    if value is None:
+        return 80, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, "confidence must be an integer between 0 and 100"
+    if value < 0 or value > 100:
+        return None, "confidence must be an integer between 0 and 100"
+    return value, None
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    if not isinstance(arguments, dict):
+        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+
+    content_raw = arguments.get("content")
+    if not isinstance(content_raw, str) or not content_raw.strip():
+        return _error_response("content is required and must be a non-empty string")
+    content = content_raw.strip()
+
+    objects, objects_error = _normalize_string_list(
+        arguments.get("objects"),
+        "objects",
+        required=True,
+    )
+    if objects_error:
+        return _error_response(objects_error)
+    assert objects is not None  # appease type checker after required=True
+
+    note_types, note_types_error = _normalize_string_list(arguments.get("note_types"), "note_types")
+    if note_types_error:
+        return _error_response(note_types_error)
+    if note_types is None:
+        note_types = ["external"]
+
+    confidence, confidence_error = _normalize_confidence(arguments.get("confidence"))
+    if confidence_error:
+        return _error_response(confidence_error)
+
+    input_payload: dict[str, Any] = {
+        "content": content,
+        "objects": objects,
+        "note_types": note_types,
+        "confidence": confidence,
+    }
+
+    attribute_abstract = arguments.get("attribute_abstract")
+    if attribute_abstract is not None:
+        if not isinstance(attribute_abstract, str) or not attribute_abstract.strip():
+            return _error_response(
+                "attribute_abstract must be a non-empty string when provided"
+            )
+        input_payload["attribute_abstract"] = attribute_abstract.strip()
+
+    try:
+        result = await session.execute(
+            gql(ADD_NOTE_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return _error_response(str(error))
+
+    note_data = result.get("noteAdd", {})
+    return _success_response(note_data)

--- a/opencti_mcp/tools/add_objects_to_case_rfi.py
+++ b/opencti_mcp/tools/add_objects_to_case_rfi.py
@@ -1,0 +1,180 @@
+from typing import Any, Callable
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+_CASE_RFI_EDIT_RELATION_MUTATION = """
+mutation AddObjectToCaseRfi($id: String!, $input: StixRefRelationshipAddInput!) {
+  result: caseRfiEdit(id: $id) {
+    relationAdd(input: $input) {
+      id
+    }
+  }
+}
+"""
+
+_CASE_RFI_EDIT_RELATION_MUTATION_ALT = """
+mutation AddObjectToCaseRfi($id: String!, $input: RelationAddInput!) {
+  result: caseRfiEdit(id: $id) {
+    relationAdd(input: $input) {
+      id
+    }
+  }
+}
+"""
+
+_GENERIC_RELATIONSHIP_MUTATION = """
+mutation AddObjectToCaseRfi($input: StixCoreRelationshipAddInput!) {
+  result: stixCoreRelationshipAdd(input: $input) {
+    id
+    relationship_type
+  }
+}
+"""
+
+
+def _build_case_rfi_relation_variables(
+    case_rfi_id: str,
+    object_id: str,
+    relationship_key: str,
+) -> dict[str, Any]:
+    return {
+        "id": case_rfi_id,
+        "input": {
+            "toId": object_id,
+            relationship_key: "object",
+        },
+    }
+
+
+def _build_generic_relationship_variables(
+    case_rfi_id: str,
+    object_id: str,
+    relationship_key: str,
+) -> dict[str, Any]:
+    return {
+        "input": {
+            "fromId": case_rfi_id,
+            "toId": object_id,
+            relationship_key: "object",
+        },
+    }
+
+
+def _mutation_candidates(case_rfi_id: str, object_id: str) -> list[tuple[str, dict[str, Any]]]:
+    variable_builders: list[tuple[str, Callable[[str, str, str], dict[str, Any]], str]] = [
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION,
+            _build_case_rfi_relation_variables,
+            "relationship_type",
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION,
+            _build_case_rfi_relation_variables,
+            "relationshipType",
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
+            _build_case_rfi_relation_variables,
+            "relationship_type",
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
+            _build_case_rfi_relation_variables,
+            "relationshipType",
+        ),
+        (
+            _GENERIC_RELATIONSHIP_MUTATION,
+            _build_generic_relationship_variables,
+            "relationship_type",
+        ),
+        (
+            _GENERIC_RELATIONSHIP_MUTATION,
+            _build_generic_relationship_variables,
+            "relationshipType",
+        ),
+    ]
+
+    return [
+        (mutation, builder(case_rfi_id, object_id, relationship_key))
+        for mutation, builder, relationship_key in variable_builders
+    ]
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    case_rfi_id, case_rfi_id_error = normalize_non_empty_string(
+        arguments.get("id"),
+        "id",
+        required=True,
+    )
+    if case_rfi_id_error:
+        return error_response(case_rfi_id_error)
+    assert case_rfi_id is not None
+
+    object_ids, object_ids_error = normalize_string_list(
+        arguments.get("object_ids"),
+        "object_ids",
+        required=True,
+    )
+    if object_ids_error:
+        return error_response(object_ids_error)
+    assert object_ids is not None
+
+    unique_object_ids = list(dict.fromkeys(object_ids))
+
+    added_object_ids: list[str] = []
+    mutation_results: list[Any] = []
+    failures: list[tuple[str, str]] = []
+
+    for object_id in unique_object_ids:
+        candidate_errors: list[str] = []
+        for mutation, variables in _mutation_candidates(case_rfi_id, object_id):
+            try:
+                result = await session.execute(gql(mutation), variable_values=variables)
+                added_object_ids.append(object_id)
+                mutation_results.append(result.get("result", result))
+                break
+            except Exception as error:  # noqa: BLE001
+                candidate_errors.append(str(error))
+        else:
+            last_error = candidate_errors[-1] if candidate_errors else "unknown schema mismatch"
+            failures.append((object_id, last_error))
+
+    if failures:
+        failure_preview = "; ".join(f"{object_id}: {error}" for object_id, error in failures[:3])
+        return error_response(
+            (
+                f"Failed to add {len(failures)} of {len(unique_object_ids)} object(s) "
+                f"to case RFI {case_rfi_id}. "
+                f"Added: {len(added_object_ids)}. Details: {failure_preview}"
+            )
+        )
+
+    return success_response(
+        {
+            "case_rfi_id": case_rfi_id,
+            "added_object_ids": added_object_ids,
+            "results": mutation_results,
+        }
+    )

--- a/opencti_mcp/tools/add_objects_to_case_rfi.py
+++ b/opencti_mcp/tools/add_objects_to_case_rfi.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any
 
 from gql import gql
 from mcp import types as mcp_types
@@ -16,6 +16,15 @@ _MUTATIONS_DISABLED_MESSAGE = (
     "Mutations are disabled. Start the server with --enable-mutations "
     "or set OPENCTI_ENABLE_MUTATIONS=true."
 )
+
+_STIX_REF_RELATIONSHIP_ADD_MUTATION = """
+mutation AddObjectToCaseRfi($input: StixRefRelationshipAddInput!) {
+  result: stixRefRelationshipAdd(input: $input) {
+    id
+    relationship_type
+  }
+}
+"""
 
 _CASE_RFI_EDIT_RELATION_MUTATION = """
 mutation AddObjectToCaseRfi($id: String!, $input: StixRefRelationshipAddInput!) {
@@ -37,14 +46,18 @@ mutation AddObjectToCaseRfi($id: String!, $input: RelationAddInput!) {
 }
 """
 
-_GENERIC_RELATIONSHIP_MUTATION = """
-mutation AddObjectToCaseRfi($input: StixCoreRelationshipAddInput!) {
-  result: stixCoreRelationshipAdd(input: $input) {
-    id
-    relationship_type
-  }
-}
-"""
+
+def _build_stix_ref_relationship_variables(
+    case_rfi_id: str,
+    object_id: str,
+) -> dict[str, Any]:
+    return {
+        "input": {
+            "fromId": case_rfi_id,
+            "toId": object_id,
+            "relationship_type": "object",
+        },
+    }
 
 
 def _build_case_rfi_relation_variables(
@@ -61,57 +74,44 @@ def _build_case_rfi_relation_variables(
     }
 
 
-def _build_generic_relationship_variables(
-    case_rfi_id: str,
-    object_id: str,
-    relationship_key: str,
-) -> dict[str, Any]:
-    return {
-        "input": {
-            "fromId": case_rfi_id,
-            "toId": object_id,
-            relationship_key: "object",
-        },
-    }
-
-
 def _mutation_candidates(case_rfi_id: str, object_id: str) -> list[tuple[str, dict[str, Any]]]:
-    variable_builders: list[tuple[str, Callable[[str, str, str], dict[str, Any]], str]] = [
-        (
-            _CASE_RFI_EDIT_RELATION_MUTATION,
-            _build_case_rfi_relation_variables,
-            "relationship_type",
-        ),
-        (
-            _CASE_RFI_EDIT_RELATION_MUTATION,
-            _build_case_rfi_relation_variables,
-            "relationshipType",
-        ),
-        (
-            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
-            _build_case_rfi_relation_variables,
-            "relationship_type",
-        ),
-        (
-            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
-            _build_case_rfi_relation_variables,
-            "relationshipType",
-        ),
-        (
-            _GENERIC_RELATIONSHIP_MUTATION,
-            _build_generic_relationship_variables,
-            "relationship_type",
-        ),
-        (
-            _GENERIC_RELATIONSHIP_MUTATION,
-            _build_generic_relationship_variables,
-            "relationshipType",
-        ),
-    ]
-
     return [
-        (mutation, builder(case_rfi_id, object_id, relationship_key))
-        for mutation, builder, relationship_key in variable_builders
+        (
+            _STIX_REF_RELATIONSHIP_ADD_MUTATION,
+            _build_stix_ref_relationship_variables(case_rfi_id, object_id),
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION,
+            _build_case_rfi_relation_variables(
+                case_rfi_id,
+                object_id,
+                "relationship_type",
+            ),
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION,
+            _build_case_rfi_relation_variables(
+                case_rfi_id,
+                object_id,
+                "relationshipType",
+            ),
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
+            _build_case_rfi_relation_variables(
+                case_rfi_id,
+                object_id,
+                "relationship_type",
+            ),
+        ),
+        (
+            _CASE_RFI_EDIT_RELATION_MUTATION_ALT,
+            _build_case_rfi_relation_variables(
+                case_rfi_id,
+                object_id,
+                "relationshipType",
+            ),
+        ),
     ]
 
 

--- a/opencti_mcp/tools/create_case_rfi.py
+++ b/opencti_mcp/tools/create_case_rfi.py
@@ -1,0 +1,175 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+_CREATE_CASE_RFI_MUTATIONS = (
+    ("caseRfiAdd", "CaseRfiAddInput!"),
+    ("rfiAdd", "RfiAddInput!"),
+    ("caseRfiAdd", "RfiAddInput!"),
+    ("rfiAdd", "CaseRfiAddInput!"),
+)
+
+
+def _build_create_mutation(mutation_name: str, input_type: str) -> str:
+    return f"""
+mutation CreateCaseRfi($input: {input_type}) {{
+  result: {mutation_name}(input: $input) {{
+    id
+    name
+    description
+  }}
+}}
+"""
+
+
+def _dedupe_payloads(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique_payloads: list[dict[str, Any]] = []
+    for payload in payloads:
+        if payload not in unique_payloads:
+            unique_payloads.append(payload)
+    return unique_payloads
+
+
+def _payload_candidates(
+    base_payload: dict[str, Any],
+    minimal_payload: dict[str, Any],
+    pir_id: str | None,
+) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for payload in (base_payload, minimal_payload):
+        if pir_id:
+            with_snake_case = payload.copy()
+            with_snake_case["pir_id"] = pir_id
+            payloads.append(with_snake_case)
+
+            with_camel_case = payload.copy()
+            with_camel_case["pirId"] = pir_id
+            payloads.append(with_camel_case)
+        payloads.append(payload.copy())
+    return _dedupe_payloads(payloads)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    name, name_error = normalize_non_empty_string(arguments.get("name"), "name", required=True)
+    if name_error:
+        return error_response(name_error)
+    assert name is not None
+
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"),
+        "description",
+    )
+    if description_error:
+        return error_response(description_error)
+
+    content, content_error = normalize_non_empty_string(arguments.get("content"), "content")
+    if content_error:
+        return error_response(content_error)
+
+    severity, severity_error = normalize_non_empty_string(arguments.get("severity"), "severity")
+    if severity_error:
+        return error_response(severity_error)
+
+    pir_id, pir_id_error = normalize_non_empty_string(arguments.get("pir_id"), "pir_id")
+    if pir_id_error:
+        return error_response(pir_id_error)
+
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
+    if confidence_error:
+        return error_response(confidence_error)
+    assert confidence is not None
+
+    object_marking, object_marking_error = normalize_string_list(
+        arguments.get("object_marking"),
+        "object_marking",
+    )
+    if object_marking_error:
+        return error_response(object_marking_error)
+
+    object_label, object_label_error = normalize_string_list(
+        arguments.get("object_label"),
+        "object_label",
+    )
+    if object_label_error:
+        return error_response(object_label_error)
+
+    external_references, external_references_error = normalize_string_list(
+        arguments.get("external_references"),
+        "external_references",
+    )
+    if external_references_error:
+        return error_response(external_references_error)
+
+    objects, objects_error = normalize_string_list(arguments.get("objects"), "objects")
+    if objects_error:
+        return error_response(objects_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    base_payload: dict[str, Any] = {
+        "name": name,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description:
+        base_payload["description"] = description
+    if content:
+        base_payload["content"] = content
+    if severity:
+        base_payload["severity"] = severity
+    if object_marking:
+        base_payload["objectMarking"] = object_marking
+    if object_label:
+        base_payload["objectLabel"] = object_label
+    if external_references:
+        base_payload["externalReferences"] = external_references
+    if objects:
+        base_payload["objects"] = objects
+
+    minimal_payload: dict[str, Any] = {"name": name}
+    if description:
+        minimal_payload["description"] = description
+    if update:
+        minimal_payload["update"] = update
+
+    errors: list[str] = []
+    payloads = _payload_candidates(base_payload, minimal_payload, pir_id)
+    for mutation_name, input_type in _CREATE_CASE_RFI_MUTATIONS:
+        mutation = _build_create_mutation(mutation_name, input_type)
+        for payload in payloads:
+            try:
+                result = await session.execute(gql(mutation), variable_values={"input": payload})
+                return success_response(result.get("result", {}))
+            except Exception as error:  # noqa: BLE001
+                errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to create case RFI with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/create_external_reference.py
+++ b/opencti_mcp/tools/create_external_reference.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_EXTERNAL_REFERENCE_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    source_name, source_name_error = normalize_non_empty_string(
+        arguments.get("source_name"), "source_name"
+    )
+    if source_name_error:
+        return error_response(source_name_error)
+
+    url, url_error = normalize_non_empty_string(arguments.get("url"), "url")
+    if url_error:
+        return error_response(url_error)
+
+    if not source_name and not url:
+        return error_response("source_name or url is required")
+
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"), "description"
+    )
+    if description_error:
+        return error_response(description_error)
+
+    external_id, external_id_error = normalize_non_empty_string(
+        arguments.get("external_id"),
+        "external_id",
+    )
+    if external_id_error:
+        return error_response(external_id_error)
+
+    x_opencti_stix_ids, x_opencti_stix_ids_error = normalize_string_list(
+        arguments.get("x_opencti_stix_ids"),
+        "x_opencti_stix_ids",
+    )
+    if x_opencti_stix_ids_error:
+        return error_response(x_opencti_stix_ids_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    input_payload: dict[str, Any] = {
+        "update": update,
+    }
+    if source_name:
+        input_payload["source_name"] = source_name
+    if url:
+        input_payload["url"] = url
+    if description:
+        input_payload["description"] = description
+    if external_id:
+        input_payload["external_id"] = external_id
+    if x_opencti_stix_ids:
+        input_payload["x_opencti_stix_ids"] = x_opencti_stix_ids
+
+    try:
+        result = await session.execute(
+            gql(CREATE_EXTERNAL_REFERENCE_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("externalReferenceAdd", {}))

--- a/opencti_mcp/tools/create_grouping.py
+++ b/opencti_mcp/tools/create_grouping.py
@@ -1,0 +1,115 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_GROUPING_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    name, name_error = normalize_non_empty_string(arguments.get("name"), "name", required=True)
+    if name_error:
+        return error_response(name_error)
+
+    context, context_error = normalize_non_empty_string(
+        arguments.get("context"),
+        "context",
+        required=True,
+    )
+    if context_error:
+        return error_response(context_error)
+    assert name is not None
+    assert context is not None
+
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"), "description"
+    )
+    if description_error:
+        return error_response(description_error)
+
+    content, content_error = normalize_non_empty_string(arguments.get("content"), "content")
+    if content_error:
+        return error_response(content_error)
+
+    objects, objects_error = normalize_string_list(arguments.get("objects"), "objects")
+    if objects_error:
+        return error_response(objects_error)
+
+    object_marking, object_marking_error = normalize_string_list(
+        arguments.get("object_marking"),
+        "object_marking",
+    )
+    if object_marking_error:
+        return error_response(object_marking_error)
+
+    object_label, object_label_error = normalize_string_list(
+        arguments.get("object_label"),
+        "object_label",
+    )
+    if object_label_error:
+        return error_response(object_label_error)
+
+    external_references, external_references_error = normalize_string_list(
+        arguments.get("external_references"),
+        "external_references",
+    )
+    if external_references_error:
+        return error_response(external_references_error)
+
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
+    if confidence_error:
+        return error_response(confidence_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    input_payload: dict[str, Any] = {
+        "name": name,
+        "context": context,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description:
+        input_payload["description"] = description
+    if content:
+        input_payload["content"] = content
+    if objects:
+        input_payload["objects"] = objects
+    if object_marking:
+        input_payload["objectMarking"] = object_marking
+    if object_label:
+        input_payload["objectLabel"] = object_label
+    if external_references:
+        input_payload["externalReferences"] = external_references
+
+    try:
+        result = await session.execute(
+            gql(CREATE_GROUPING_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("groupingAdd", {}))

--- a/opencti_mcp/tools/create_identity.py
+++ b/opencti_mcp/tools/create_identity.py
@@ -1,0 +1,117 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_IDENTITY_MUTATION, CREATE_ORGANIZATION_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    name, name_error = normalize_non_empty_string(arguments.get("name"), "name", required=True)
+    if name_error:
+        return error_response(name_error)
+    assert name is not None
+
+    identity_type, type_error = normalize_non_empty_string(arguments.get("type"), "type")
+    if type_error:
+        return error_response(type_error)
+    if not identity_type:
+        identity_type = "Organization"
+
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"), "description"
+    )
+    if description_error:
+        return error_response(description_error)
+
+    contact_information, contact_information_error = normalize_non_empty_string(
+        arguments.get("contact_information"), "contact_information"
+    )
+    if contact_information_error:
+        return error_response(contact_information_error)
+
+    object_marking, object_marking_error = normalize_string_list(
+        arguments.get("object_marking"), "object_marking"
+    )
+    if object_marking_error:
+        return error_response(object_marking_error)
+
+    object_label, object_label_error = normalize_string_list(
+        arguments.get("object_label"), "object_label"
+    )
+    if object_label_error:
+        return error_response(object_label_error)
+
+    external_references, external_references_error = normalize_string_list(
+        arguments.get("external_references"), "external_references"
+    )
+    if external_references_error:
+        return error_response(external_references_error)
+
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
+    if confidence_error:
+        return error_response(confidence_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    input_payload: dict[str, Any] = {
+        "name": name,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description:
+        input_payload["description"] = description
+    if contact_information:
+        input_payload["contact_information"] = contact_information
+    if object_marking:
+        input_payload["objectMarking"] = object_marking
+    if object_label:
+        input_payload["objectLabel"] = object_label
+    if external_references:
+        input_payload["externalReferences"] = external_references
+
+    if identity_type == "Organization":
+        x_opencti_organization_type, organization_type_error = normalize_non_empty_string(
+            arguments.get("x_opencti_organization_type"),
+            "x_opencti_organization_type",
+        )
+        if organization_type_error:
+            return error_response(organization_type_error)
+        if x_opencti_organization_type:
+            input_payload["x_opencti_organization_type"] = x_opencti_organization_type
+        mutation = CREATE_ORGANIZATION_MUTATION
+        result_key = "organizationAdd"
+    else:
+        input_payload["type"] = identity_type
+        mutation = CREATE_IDENTITY_MUTATION
+        result_key = "identityAdd"
+
+    try:
+        result = await session.execute(gql(mutation), variable_values={"input": input_payload})
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get(result_key, {}))

--- a/opencti_mcp/tools/create_label.py
+++ b/opencti_mcp/tools/create_label.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_LABEL_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    value, value_error = normalize_non_empty_string(arguments.get("value"), "value", required=True)
+    if value_error:
+        return error_response(value_error)
+    assert value is not None
+
+    color, color_error = normalize_non_empty_string(arguments.get("color"), "color")
+    if color_error:
+        return error_response(color_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    input_payload: dict[str, Any] = {
+        "value": value,
+        "update": update,
+    }
+    if color:
+        input_payload["color"] = color
+
+    try:
+        result = await session.execute(
+            gql(CREATE_LABEL_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("labelAdd", {}))

--- a/opencti_mcp/tools/create_pir.py
+++ b/opencti_mcp/tools/create_pir.py
@@ -1,0 +1,156 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+_CREATE_PIR_MUTATIONS = (
+    ("casePirAdd", "CasePirAddInput!"),
+    ("pirAdd", "PirAddInput!"),
+    ("casePirAdd", "PirAddInput!"),
+    ("pirAdd", "CasePirAddInput!"),
+)
+
+
+def _build_create_mutation(mutation_name: str, input_type: str) -> str:
+    return f"""
+mutation CreatePir($input: {input_type}) {{
+  result: {mutation_name}(input: $input) {{
+    id
+    name
+    description
+  }}
+}}
+"""
+
+
+def _payload_candidates(base_payload: dict[str, Any], minimal_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates = [base_payload]
+    if minimal_payload != base_payload:
+        candidates.append(minimal_payload)
+    return candidates
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    name, name_error = normalize_non_empty_string(arguments.get("name"), "name", required=True)
+    if name_error:
+        return error_response(name_error)
+    assert name is not None
+
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"),
+        "description",
+    )
+    if description_error:
+        return error_response(description_error)
+
+    content, content_error = normalize_non_empty_string(arguments.get("content"), "content")
+    if content_error:
+        return error_response(content_error)
+
+    priority, priority_error = normalize_non_empty_string(arguments.get("priority"), "priority")
+    if priority_error:
+        return error_response(priority_error)
+
+    severity, severity_error = normalize_non_empty_string(arguments.get("severity"), "severity")
+    if severity_error:
+        return error_response(severity_error)
+
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
+    if confidence_error:
+        return error_response(confidence_error)
+    assert confidence is not None
+
+    object_marking, object_marking_error = normalize_string_list(
+        arguments.get("object_marking"),
+        "object_marking",
+    )
+    if object_marking_error:
+        return error_response(object_marking_error)
+
+    object_label, object_label_error = normalize_string_list(
+        arguments.get("object_label"),
+        "object_label",
+    )
+    if object_label_error:
+        return error_response(object_label_error)
+
+    external_references, external_references_error = normalize_string_list(
+        arguments.get("external_references"),
+        "external_references",
+    )
+    if external_references_error:
+        return error_response(external_references_error)
+
+    objects, objects_error = normalize_string_list(arguments.get("objects"), "objects")
+    if objects_error:
+        return error_response(objects_error)
+
+    update = arguments.get("update", False)
+    if not isinstance(update, bool):
+        return error_response("update must be a boolean")
+
+    base_payload: dict[str, Any] = {
+        "name": name,
+        "confidence": confidence,
+        "update": update,
+    }
+    if description:
+        base_payload["description"] = description
+    if content:
+        base_payload["content"] = content
+    if priority:
+        base_payload["priority"] = priority
+    if severity:
+        base_payload["severity"] = severity
+    if object_marking:
+        base_payload["objectMarking"] = object_marking
+    if object_label:
+        base_payload["objectLabel"] = object_label
+    if external_references:
+        base_payload["externalReferences"] = external_references
+    if objects:
+        base_payload["objects"] = objects
+
+    minimal_payload: dict[str, Any] = {"name": name}
+    if description:
+        minimal_payload["description"] = description
+    if update:
+        minimal_payload["update"] = update
+
+    errors: list[str] = []
+    for mutation_name, input_type in _CREATE_PIR_MUTATIONS:
+        mutation = _build_create_mutation(mutation_name, input_type)
+        for payload in _payload_candidates(base_payload, minimal_payload):
+            try:
+                result = await session.execute(gql(mutation), variable_values={"input": payload})
+                return success_response(result.get("result", {}))
+            except Exception as error:  # noqa: BLE001
+                errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to create PIR with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/create_pir.py
+++ b/opencti_mcp/tools/create_pir.py
@@ -6,7 +6,6 @@ from mcp import types as mcp_types
 from opencti_mcp.tools.tool_helpers import (
     ensure_arguments_dict,
     error_response,
-    normalize_confidence,
     normalize_non_empty_string,
     normalize_string_list,
     success_response,
@@ -18,31 +17,166 @@ _MUTATIONS_DISABLED_MESSAGE = (
     "or set OPENCTI_ENABLE_MUTATIONS=true."
 )
 
-_CREATE_PIR_MUTATIONS = (
-    ("casePirAdd", "CasePirAddInput!"),
-    ("pirAdd", "PirAddInput!"),
-    ("casePirAdd", "PirAddInput!"),
-    ("pirAdd", "CasePirAddInput!"),
-)
-
-
-def _build_create_mutation(mutation_name: str, input_type: str) -> str:
-    return f"""
-mutation CreatePir($input: {input_type}) {{
-  result: {mutation_name}(input: $input) {{
+_CREATE_PIR_MUTATION = """
+mutation CreatePir($input: PirAddInput!) {
+  pirAdd(input: $input) {
     id
     name
     description
-  }}
-}}
+  }
+}
 """
+_ALLOWED_PIR_TYPES = {"THREAT_LANDSCAPE", "THREAT_ORIGIN", "THREAT_CUSTOM"}
+_ALLOWED_FILTER_MODES = {"and", "or"}
 
 
-def _payload_candidates(base_payload: dict[str, Any], minimal_payload: dict[str, Any]) -> list[dict[str, Any]]:
-    candidates = [base_payload]
-    if minimal_payload != base_payload:
-        candidates.append(minimal_payload)
-    return candidates
+def _default_filter_group() -> dict[str, Any]:
+    return {
+        "mode": "and",
+        "filters": [],
+        "filterGroups": [],
+    }
+
+
+def _normalize_positive_int(value: Any, field_name: str, default: int) -> tuple[int | None, str | None]:
+    if value is None:
+        return default, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, f"{field_name} must be a positive integer"
+    if value < 1:
+        return None, f"{field_name} must be a positive integer"
+    return value, None
+
+
+def _normalize_filter(value: Any, field_name: str) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(value, dict):
+        return None, f"{field_name} must be an object"
+
+    key, key_error = normalize_string_list(value.get("key"), f"{field_name}.key", required=True)
+    if key_error:
+        return None, key_error
+    assert key is not None
+
+    values, values_error = normalize_string_list(
+        value.get("values"),
+        f"{field_name}.values",
+        required=True,
+    )
+    if values_error:
+        return None, values_error
+    assert values is not None
+
+    normalized_filter: dict[str, Any] = {
+        "key": key,
+        "values": values,
+    }
+
+    operator, operator_error = normalize_non_empty_string(value.get("operator"), f"{field_name}.operator")
+    if operator_error:
+        return None, operator_error
+    if operator:
+        normalized_filter["operator"] = operator
+
+    mode, mode_error = normalize_non_empty_string(value.get("mode"), f"{field_name}.mode")
+    if mode_error:
+        return None, mode_error
+    if mode:
+        if mode not in _ALLOWED_FILTER_MODES:
+            return None, f"{field_name}.mode must be one of: {', '.join(sorted(_ALLOWED_FILTER_MODES))}"
+        normalized_filter["mode"] = mode
+
+    return normalized_filter, None
+
+
+def _normalize_filter_group(
+    value: Any,
+    field_name: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if value is None:
+        return _default_filter_group(), None
+    if not isinstance(value, dict):
+        return None, f"{field_name} must be an object"
+
+    mode, mode_error = normalize_non_empty_string(value.get("mode"), f"{field_name}.mode", required=True)
+    if mode_error:
+        return None, mode_error
+    assert mode is not None
+    if mode not in _ALLOWED_FILTER_MODES:
+        return None, f"{field_name}.mode must be one of: {', '.join(sorted(_ALLOWED_FILTER_MODES))}"
+
+    filters_raw = value.get("filters", [])
+    if not isinstance(filters_raw, list):
+        return None, f"{field_name}.filters must be a list"
+    filters: list[dict[str, Any]] = []
+    for index, filter_value in enumerate(filters_raw):
+        normalized_filter, filter_error = _normalize_filter(
+            filter_value,
+            f"{field_name}.filters[{index}]",
+        )
+        if filter_error:
+            return None, filter_error
+        assert normalized_filter is not None
+        filters.append(normalized_filter)
+
+    filter_groups_raw = value.get("filterGroups", [])
+    if not isinstance(filter_groups_raw, list):
+        return None, f"{field_name}.filterGroups must be a list"
+    filter_groups: list[dict[str, Any]] = []
+    for index, group_value in enumerate(filter_groups_raw):
+        normalized_group, group_error = _normalize_filter_group(
+            group_value,
+            f"{field_name}.filterGroups[{index}]",
+        )
+        if group_error:
+            return None, group_error
+        assert normalized_group is not None
+        filter_groups.append(normalized_group)
+
+    return {
+        "mode": mode,
+        "filters": filters,
+        "filterGroups": filter_groups,
+    }, None
+
+
+def _normalize_pir_criteria(value: Any) -> tuple[list[dict[str, Any]] | None, str | None]:
+    if value is None:
+        return [{"weight": 1, "filters": _default_filter_group()}], None
+    if not isinstance(value, list):
+        return None, "pir_criteria must be a list of objects"
+    if not value:
+        return None, "pir_criteria cannot be empty"
+
+    criteria: list[dict[str, Any]] = []
+    for index, criterion in enumerate(value):
+        if not isinstance(criterion, dict):
+            return None, f"pir_criteria[{index}] must be an object"
+
+        weight, weight_error = _normalize_positive_int(
+            criterion.get("weight"),
+            f"pir_criteria[{index}].weight",
+            default=1,
+        )
+        if weight_error:
+            return None, weight_error
+        assert weight is not None
+
+        filters, filters_error = _normalize_filter_group(
+            criterion.get("filters"),
+            f"pir_criteria[{index}].filters",
+        )
+        if filters_error:
+            return None, filters_error
+        assert filters is not None
+
+        criteria.append(
+            {
+                "weight": weight,
+                "filters": filters,
+            }
+        )
+
+    return criteria, None
 
 
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
@@ -65,92 +199,54 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
     if description_error:
         return error_response(description_error)
 
-    content, content_error = normalize_non_empty_string(arguments.get("content"), "content")
-    if content_error:
-        return error_response(content_error)
+    pir_type, pir_type_error = normalize_non_empty_string(arguments.get("pir_type"), "pir_type")
+    if pir_type_error:
+        return error_response(pir_type_error)
+    if pir_type is None:
+        pir_type = "THREAT_CUSTOM"
+    if pir_type not in _ALLOWED_PIR_TYPES:
+        return error_response(
+            f"pir_type must be one of: {', '.join(sorted(_ALLOWED_PIR_TYPES))}"
+        )
 
-    priority, priority_error = normalize_non_empty_string(arguments.get("priority"), "priority")
-    if priority_error:
-        return error_response(priority_error)
-
-    severity, severity_error = normalize_non_empty_string(arguments.get("severity"), "severity")
-    if severity_error:
-        return error_response(severity_error)
-
-    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
-    if confidence_error:
-        return error_response(confidence_error)
-    assert confidence is not None
-
-    object_marking, object_marking_error = normalize_string_list(
-        arguments.get("object_marking"),
-        "object_marking",
+    pir_rescan_days, pir_rescan_days_error = _normalize_positive_int(
+        arguments.get("pir_rescan_days"),
+        "pir_rescan_days",
+        default=30,
     )
-    if object_marking_error:
-        return error_response(object_marking_error)
+    if pir_rescan_days_error:
+        return error_response(pir_rescan_days_error)
+    assert pir_rescan_days is not None
 
-    object_label, object_label_error = normalize_string_list(
-        arguments.get("object_label"),
-        "object_label",
+    pir_filters, pir_filters_error = _normalize_filter_group(
+        arguments.get("pir_filters"),
+        "pir_filters",
     )
-    if object_label_error:
-        return error_response(object_label_error)
+    if pir_filters_error:
+        return error_response(pir_filters_error)
+    assert pir_filters is not None
 
-    external_references, external_references_error = normalize_string_list(
-        arguments.get("external_references"),
-        "external_references",
-    )
-    if external_references_error:
-        return error_response(external_references_error)
+    pir_criteria, pir_criteria_error = _normalize_pir_criteria(arguments.get("pir_criteria"))
+    if pir_criteria_error:
+        return error_response(pir_criteria_error)
+    assert pir_criteria is not None
 
-    objects, objects_error = normalize_string_list(arguments.get("objects"), "objects")
-    if objects_error:
-        return error_response(objects_error)
-
-    update = arguments.get("update", False)
-    if not isinstance(update, bool):
-        return error_response("update must be a boolean")
-
-    base_payload: dict[str, Any] = {
+    input_payload: dict[str, Any] = {
         "name": name,
-        "confidence": confidence,
-        "update": update,
+        "pir_type": pir_type,
+        "pir_rescan_days": pir_rescan_days,
+        "pir_filters": pir_filters,
+        "pir_criteria": pir_criteria,
     }
     if description:
-        base_payload["description"] = description
-    if content:
-        base_payload["content"] = content
-    if priority:
-        base_payload["priority"] = priority
-    if severity:
-        base_payload["severity"] = severity
-    if object_marking:
-        base_payload["objectMarking"] = object_marking
-    if object_label:
-        base_payload["objectLabel"] = object_label
-    if external_references:
-        base_payload["externalReferences"] = external_references
-    if objects:
-        base_payload["objects"] = objects
+        input_payload["description"] = description
 
-    minimal_payload: dict[str, Any] = {"name": name}
-    if description:
-        minimal_payload["description"] = description
-    if update:
-        minimal_payload["update"] = update
+    try:
+        result = await session.execute(
+            gql(_CREATE_PIR_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
 
-    errors: list[str] = []
-    for mutation_name, input_type in _CREATE_PIR_MUTATIONS:
-        mutation = _build_create_mutation(mutation_name, input_type)
-        for payload in _payload_candidates(base_payload, minimal_payload):
-            try:
-                result = await session.execute(gql(mutation), variable_values={"input": payload})
-                return success_response(result.get("result", {}))
-            except Exception as error:  # noqa: BLE001
-                errors.append(str(error))
-
-    last_error = errors[-1] if errors else "unknown schema mismatch"
-    return error_response(
-        "Unable to create PIR with the available GraphQL schema variants. "
-        f"Last error: {last_error}"
-    )
+    return success_response(result.get("pirAdd", {}))

--- a/opencti_mcp/tools/create_relationship.py
+++ b/opencti_mcp/tools/create_relationship.py
@@ -1,10 +1,15 @@
-import json
 from typing import Any
 
 from gql import gql
 from mcp import types as mcp_types
 
 from opencti_mcp.graphql_queries import CREATE_RELATIONSHIP_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
 from opencti_mcp.utils.mutations import mutations_enabled
 
 _MUTATIONS_DISABLED_MESSAGE = (
@@ -13,50 +18,40 @@ _MUTATIONS_DISABLED_MESSAGE = (
 )
 
 
-def _error_response(message: str) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": False, "error": message}, indent=2),
-        )
-    ]
-
-
-def _success_response(data: Any) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": True, "data": data}, indent=2),
-        )
-    ]
-
-
-def _normalize_required_string(value: Any, field_name: str) -> tuple[str | None, str | None]:
-    if not isinstance(value, str) or not value.strip():
-        return None, f"{field_name} is required and must be a non-empty string"
-    return value.strip(), None
-
-
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
     if not mutations_enabled():
-        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
 
-    if not isinstance(arguments, dict):
-        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
 
-    from_id, from_id_error = _normalize_required_string(arguments.get("fromId"), "fromId")
+    from_id, from_id_error = normalize_non_empty_string(
+        arguments.get("fromId"),
+        "fromId",
+        required=True,
+    )
     if from_id_error:
-        return _error_response(from_id_error)
+        return error_response(from_id_error)
+    assert from_id is not None
 
-    to_id, to_id_error = _normalize_required_string(arguments.get("toId"), "toId")
+    to_id, to_id_error = normalize_non_empty_string(
+        arguments.get("toId"),
+        "toId",
+        required=True,
+    )
     if to_id_error:
-        return _error_response(to_id_error)
+        return error_response(to_id_error)
+    assert to_id is not None
 
-    relationship_type, relationship_type_error = _normalize_required_string(
-        arguments.get("relationship_type"), "relationship_type"
+    relationship_type, relationship_type_error = normalize_non_empty_string(
+        arguments.get("relationship_type"),
+        "relationship_type",
+        required=True,
     )
     if relationship_type_error:
-        return _error_response(relationship_type_error)
+        return error_response(relationship_type_error)
+    assert relationship_type is not None
 
     input_payload = {
         "fromId": from_id,
@@ -70,7 +65,7 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
             variable_values={"input": input_payload},
         )
     except Exception as error:  # noqa: BLE001
-        return _error_response(str(error))
+        return error_response(str(error))
 
     relationship_data = result.get("stixCoreRelationshipAdd", {})
-    return _success_response(relationship_data)
+    return success_response(relationship_data)

--- a/opencti_mcp/tools/create_relationship.py
+++ b/opencti_mcp/tools/create_relationship.py
@@ -1,0 +1,76 @@
+import json
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_RELATIONSHIP_MUTATION
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+def _error_response(message: str) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": False, "error": message}, indent=2),
+        )
+    ]
+
+
+def _success_response(data: Any) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": True, "data": data}, indent=2),
+        )
+    ]
+
+
+def _normalize_required_string(value: Any, field_name: str) -> tuple[str | None, str | None]:
+    if not isinstance(value, str) or not value.strip():
+        return None, f"{field_name} is required and must be a non-empty string"
+    return value.strip(), None
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    if not isinstance(arguments, dict):
+        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+
+    from_id, from_id_error = _normalize_required_string(arguments.get("fromId"), "fromId")
+    if from_id_error:
+        return _error_response(from_id_error)
+
+    to_id, to_id_error = _normalize_required_string(arguments.get("toId"), "toId")
+    if to_id_error:
+        return _error_response(to_id_error)
+
+    relationship_type, relationship_type_error = _normalize_required_string(
+        arguments.get("relationship_type"), "relationship_type"
+    )
+    if relationship_type_error:
+        return _error_response(relationship_type_error)
+
+    input_payload = {
+        "fromId": from_id,
+        "toId": to_id,
+        "relationship_type": relationship_type,
+    }
+
+    try:
+        result = await session.execute(
+            gql(CREATE_RELATIONSHIP_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return _error_response(str(error))
+
+    relationship_data = result.get("stixCoreRelationshipAdd", {})
+    return _success_response(relationship_data)

--- a/opencti_mcp/tools/create_report.py
+++ b/opencti_mcp/tools/create_report.py
@@ -1,10 +1,17 @@
-import json
 from typing import Any
 
 from gql import gql
 from mcp import types as mcp_types
 
 from opencti_mcp.graphql_queries import CREATE_REPORT_MUTATION
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_confidence,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
 from opencti_mcp.utils.mutations import mutations_enabled
 
 _MUTATIONS_DISABLED_MESSAGE = (
@@ -13,97 +20,49 @@ _MUTATIONS_DISABLED_MESSAGE = (
 )
 
 
-def _error_response(message: str) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": False, "error": message}, indent=2),
-        )
-    ]
-
-
-def _success_response(data: Any) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": True, "data": data}, indent=2),
-        )
-    ]
-
-
-def _normalize_string_list(
-    value: Any, field_name: str, *, required: bool = False
-) -> tuple[list[str] | None, str | None]:
-    if value is None:
-        if required:
-            return None, f"{field_name} is required"
-        return None, None
-
-    if not isinstance(value, list):
-        return None, f"{field_name} must be a list of strings"
-
-    normalized: list[str] = []
-    for item in value:
-        if not isinstance(item, str):
-            return None, f"{field_name} must only contain strings"
-        cleaned = item.strip()
-        if not cleaned:
-            return None, f"{field_name} cannot contain empty strings"
-        normalized.append(cleaned)
-
-    if required and not normalized:
-        return None, f"{field_name} cannot be empty"
-
-    return normalized, None
-
-
-def _normalize_confidence(value: Any) -> tuple[int | None, str | None]:
-    if value is None:
-        return 80, None
-    if isinstance(value, bool) or not isinstance(value, int):
-        return None, "confidence must be an integer between 0 and 100"
-    if value < 0 or value > 100:
-        return None, "confidence must be an integer between 0 and 100"
-    return value, None
-
-
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
     if not mutations_enabled():
-        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+        return error_response(_MUTATIONS_DISABLED_MESSAGE)
 
-    if not isinstance(arguments, dict):
-        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
 
-    name_raw = arguments.get("name")
-    if not isinstance(name_raw, str) or not name_raw.strip():
-        return _error_response("name is required and must be a non-empty string")
-    name = name_raw.strip()
+    name, name_error = normalize_non_empty_string(arguments.get("name"), "name", required=True)
+    if name_error:
+        return error_response(name_error)
+    assert name is not None
 
-    description_raw = arguments.get("description")
-    if not isinstance(description_raw, str) or not description_raw.strip():
-        return _error_response("description is required and must be a non-empty string")
-    description = description_raw.strip()
+    description, description_error = normalize_non_empty_string(
+        arguments.get("description"),
+        "description",
+        required=True,
+    )
+    if description_error:
+        return error_response(description_error)
+    assert description is not None
 
-    report_types, report_types_error = _normalize_string_list(
+    report_types, report_types_error = normalize_string_list(
         arguments.get("report_types"),
         "report_types",
     )
     if report_types_error:
-        return _error_response(report_types_error)
+        return error_response(report_types_error)
     if report_types is None:
         report_types = ["threat-report"]
 
-    confidence, confidence_error = _normalize_confidence(arguments.get("confidence"))
+    confidence, confidence_error = normalize_confidence(arguments.get("confidence"), default=80)
     if confidence_error:
-        return _error_response(confidence_error)
+        return error_response(confidence_error)
+    assert confidence is not None
 
-    objects, objects_error = _normalize_string_list(arguments.get("objects"), "objects")
+    objects, objects_error = normalize_string_list(arguments.get("objects"), "objects")
     if objects_error:
-        return _error_response(objects_error)
+        return error_response(objects_error)
 
-    labels, labels_error = _normalize_string_list(arguments.get("labels"), "labels")
+    labels, labels_error = normalize_string_list(arguments.get("labels"), "labels")
     if labels_error:
-        return _error_response(labels_error)
+        return error_response(labels_error)
 
     input_payload: dict[str, Any] = {
         "name": name,
@@ -112,11 +71,14 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
         "confidence": confidence,
     }
 
-    published = arguments.get("published")
-    if published is not None:
-        if not isinstance(published, str) or not published.strip():
-            return _error_response("published must be a non-empty ISO date string when provided")
-        input_payload["published"] = published.strip()
+    published_raw = arguments.get("published")
+    published, published_error = normalize_non_empty_string(published_raw, "published")
+    if published_error:
+        return error_response(published_error)
+    if published_raw is not None and published is None:
+        return error_response("published must be a non-empty ISO date string when provided")
+    if published:
+        input_payload["published"] = published
 
     if objects:
         input_payload["objects"] = objects
@@ -129,7 +91,7 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
             variable_values={"input": input_payload},
         )
     except Exception as error:  # noqa: BLE001
-        return _error_response(str(error))
+        return error_response(str(error))
 
     report_data = result.get("reportAdd", {})
-    return _success_response(report_data)
+    return success_response(report_data)

--- a/opencti_mcp/tools/create_report.py
+++ b/opencti_mcp/tools/create_report.py
@@ -1,0 +1,135 @@
+import json
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import CREATE_REPORT_MUTATION
+from opencti_mcp.utils.mutations import mutations_enabled
+
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+def _error_response(message: str) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": False, "error": message}, indent=2),
+        )
+    ]
+
+
+def _success_response(data: Any) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": True, "data": data}, indent=2),
+        )
+    ]
+
+
+def _normalize_string_list(
+    value: Any, field_name: str, *, required: bool = False
+) -> tuple[list[str] | None, str | None]:
+    if value is None:
+        if required:
+            return None, f"{field_name} is required"
+        return None, None
+
+    if not isinstance(value, list):
+        return None, f"{field_name} must be a list of strings"
+
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None, f"{field_name} must only contain strings"
+        cleaned = item.strip()
+        if not cleaned:
+            return None, f"{field_name} cannot contain empty strings"
+        normalized.append(cleaned)
+
+    if required and not normalized:
+        return None, f"{field_name} cannot be empty"
+
+    return normalized, None
+
+
+def _normalize_confidence(value: Any) -> tuple[int | None, str | None]:
+    if value is None:
+        return 80, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, "confidence must be an integer between 0 and 100"
+    if value < 0 or value > 100:
+        return None, "confidence must be an integer between 0 and 100"
+    return value, None
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not mutations_enabled():
+        return _error_response(_MUTATIONS_DISABLED_MESSAGE)
+
+    if not isinstance(arguments, dict):
+        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+
+    name_raw = arguments.get("name")
+    if not isinstance(name_raw, str) or not name_raw.strip():
+        return _error_response("name is required and must be a non-empty string")
+    name = name_raw.strip()
+
+    description_raw = arguments.get("description")
+    if not isinstance(description_raw, str) or not description_raw.strip():
+        return _error_response("description is required and must be a non-empty string")
+    description = description_raw.strip()
+
+    report_types, report_types_error = _normalize_string_list(
+        arguments.get("report_types"),
+        "report_types",
+    )
+    if report_types_error:
+        return _error_response(report_types_error)
+    if report_types is None:
+        report_types = ["threat-report"]
+
+    confidence, confidence_error = _normalize_confidence(arguments.get("confidence"))
+    if confidence_error:
+        return _error_response(confidence_error)
+
+    objects, objects_error = _normalize_string_list(arguments.get("objects"), "objects")
+    if objects_error:
+        return _error_response(objects_error)
+
+    labels, labels_error = _normalize_string_list(arguments.get("labels"), "labels")
+    if labels_error:
+        return _error_response(labels_error)
+
+    input_payload: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "report_types": report_types,
+        "confidence": confidence,
+    }
+
+    published = arguments.get("published")
+    if published is not None:
+        if not isinstance(published, str) or not published.strip():
+            return _error_response("published must be a non-empty ISO date string when provided")
+        input_payload["published"] = published.strip()
+
+    if objects:
+        input_payload["objects"] = objects
+    if labels:
+        input_payload["objectLabel"] = labels
+
+    try:
+        result = await session.execute(
+            gql(CREATE_REPORT_MUTATION),
+            variable_values={"input": input_payload},
+        )
+    except Exception as error:  # noqa: BLE001
+        return _error_response(str(error))
+
+    report_data = result.get("reportAdd", {})
+    return _success_response(report_data)

--- a/opencti_mcp/tools/execute_graphql_query.py
+++ b/opencti_mcp/tools/execute_graphql_query.py
@@ -1,37 +1,43 @@
-import json
+import re
 from typing import Any
 
 from gql import gql
 from mcp import types as mcp_types
 
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+_OPERATION_PREFIX_PATTERN = re.compile(r"^(query|mutation|subscription)\b", re.IGNORECASE)
+
+
+def _normalize_graphql_operation(query_string: str) -> str:
+    normalized = query_string.strip()
+    if _OPERATION_PREFIX_PATTERN.match(normalized):
+        return normalized
+    return f"query {normalized}"
+
 
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
-    if not isinstance(arguments, dict):
-        return [
-            mcp_types.TextContent(
-                type="text", text=f"Error: arguments must be a dictionary, got {type(arguments)}"
-            )
-        ]
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
 
-    query_string = arguments.get("query")
-    if not query_string:
-        return [
-            mcp_types.TextContent(type="text", text="Error: query parameter is missing or empty")
-        ]
+    query_string, query_error = normalize_non_empty_string(
+        arguments.get("query"),
+        "query",
+        required=True,
+    )
+    if query_error:
+        return error_response(query_error)
+    assert query_string is not None
 
     try:
-        if not query_string.strip().startswith("query"):
-            query_string = f"query {query_string}"
+        result = await session.execute(gql(_normalize_graphql_operation(query_string)))
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
 
-        result = await session.execute(gql(query_string))
-        return [
-            mcp_types.TextContent(
-                type="text", text=json.dumps({"success": True, "data": result}, indent=2)
-            )
-        ]
-    except Exception as e:  # noqa: BLE001
-        return [
-            mcp_types.TextContent(
-                type="text", text=json.dumps({"success": False, "error": str(e)}, indent=2)
-            )
-        ]
+    return success_response(result)

--- a/opencti_mcp/tools/execute_graphql_query.py
+++ b/opencti_mcp/tools/execute_graphql_query.py
@@ -10,15 +10,73 @@ from opencti_mcp.tools.tool_helpers import (
     normalize_non_empty_string,
     success_response,
 )
+from opencti_mcp.utils.mutations import mutations_enabled
 
 _OPERATION_PREFIX_PATTERN = re.compile(r"^(query|mutation|subscription)\b", re.IGNORECASE)
+_LEADING_WORD_PATTERN = re.compile(r"^([_A-Za-z][_0-9A-Za-z]*)\b")
+_MUTATION_OPERATION_LINE_PATTERN = re.compile(r"(?mi)^[ \t]*mutation\b")
+_DOCUMENT_PREFIXES = {
+    "query",
+    "mutation",
+    "subscription",
+    "fragment",
+    "schema",
+    "extend",
+    "directive",
+    "type",
+    "interface",
+    "union",
+    "scalar",
+    "enum",
+    "input",
+}
+_MUTATIONS_DISABLED_MESSAGE = (
+    "Mutations are disabled. Start the server with --enable-mutations "
+    "or set OPENCTI_ENABLE_MUTATIONS=true."
+)
+
+
+def _leading_graphql_token(query_string: str) -> str | None:
+    """Return the first significant GraphQL token, skipping blank/comment lines."""
+    for line in query_string.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("{"):
+            return "{"
+        match = _LEADING_WORD_PATTERN.match(stripped)
+        if match:
+            return match.group(1).lower()
+        return None
+    return None
 
 
 def _normalize_graphql_operation(query_string: str) -> str:
     normalized = query_string.strip()
     if _OPERATION_PREFIX_PATTERN.match(normalized):
         return normalized
+    leading_token = _leading_graphql_token(normalized)
+    if leading_token in _DOCUMENT_PREFIXES:
+        return normalized
     return f"query {normalized}"
+
+
+def _contains_mutation_operation(document: Any, query_string: str) -> bool:
+    """Detect whether the GraphQL document includes at least one mutation operation."""
+    definitions = getattr(document, "definitions", None)
+    if definitions is not None:
+        for definition in definitions:
+            operation = getattr(definition, "operation", None)
+            if operation is None:
+                continue
+            operation_name = getattr(operation, "value", None)
+            if operation_name is None:
+                operation_name = str(operation)
+            if isinstance(operation_name, str) and operation_name.lower() == "mutation":
+                return True
+
+    # Fallback for tests/mocks where gql() may be monkeypatched to return a plain string.
+    return bool(_MUTATION_OPERATION_LINE_PATTERN.search(query_string))
 
 
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
@@ -36,7 +94,11 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
     assert query_string is not None
 
     try:
-        result = await session.execute(gql(_normalize_graphql_operation(query_string)))
+        normalized_query = _normalize_graphql_operation(query_string)
+        document = gql(normalized_query)
+        if _contains_mutation_operation(document, normalized_query) and not mutations_enabled():
+            return error_response(_MUTATIONS_DISABLED_MESSAGE)
+        result = await session.execute(document)
     except Exception as error:  # noqa: BLE001
         return error_response(str(error))
 

--- a/opencti_mcp/tools/get_license_edition.py
+++ b/opencti_mcp/tools/get_license_edition.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from gql import gql
@@ -8,24 +7,11 @@ from opencti_mcp.graphql_queries import (
     GET_LICENSE_EDITION_QUERY,
     GET_LICENSE_EDITION_QUERY_CAMEL,
 )
-
-
-def _error_response(message: str) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": False, "error": message}, indent=2),
-        )
-    ]
-
-
-def _success_response(data: dict[str, Any]) -> list[mcp_types.TextContent]:
-    return [
-        mcp_types.TextContent(
-            type="text",
-            text=json.dumps({"success": True, "data": data}, indent=2),
-        )
-    ]
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    success_response,
+)
 
 
 def _extract_settings_value(settings: dict[str, Any]) -> tuple[str, Any]:
@@ -43,8 +29,9 @@ def _edition_from_value(value: Any) -> str:
 
 
 async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
-    if not isinstance(arguments, dict):
-        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
 
     errors: list[str] = []
     for query in (GET_LICENSE_EDITION_QUERY, GET_LICENSE_EDITION_QUERY_CAMEL):
@@ -52,15 +39,15 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
             result = await session.execute(gql(query))
             settings = result.get("settings")
             if not isinstance(settings, dict):
-                return _error_response("Unable to read settings from OpenCTI response")
+                return error_response("Unable to read settings from OpenCTI response")
 
             source_field, raw_value = _extract_settings_value(settings)
             if source_field == "unknown":
-                return _error_response(
+                return error_response(
                     "Unable to determine license edition: enterprise edition field not found"
                 )
 
-            return _success_response(
+            return success_response(
                 {
                     "edition": _edition_from_value(raw_value),
                     "source_field": source_field,
@@ -70,7 +57,7 @@ async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.Text
         except Exception as error:  # noqa: BLE001
             errors.append(str(error))
 
-    return _error_response(
+    return error_response(
         "Unable to determine license edition from OpenCTI settings. "
         f"Errors: {' | '.join(errors)}"
     )

--- a/opencti_mcp/tools/get_license_edition.py
+++ b/opencti_mcp/tools/get_license_edition.py
@@ -1,0 +1,76 @@
+import json
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import (
+    GET_LICENSE_EDITION_QUERY,
+    GET_LICENSE_EDITION_QUERY_CAMEL,
+)
+
+
+def _error_response(message: str) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": False, "error": message}, indent=2),
+        )
+    ]
+
+
+def _success_response(data: dict[str, Any]) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": True, "data": data}, indent=2),
+        )
+    ]
+
+
+def _extract_settings_value(settings: dict[str, Any]) -> tuple[str, Any]:
+    if "enterprise_edition" in settings:
+        return "enterprise_edition", settings.get("enterprise_edition")
+    if "enterpriseEdition" in settings:
+        return "enterpriseEdition", settings.get("enterpriseEdition")
+    return "unknown", None
+
+
+def _edition_from_value(value: Any) -> str:
+    if value in (None, "", False, 0):
+        return "CE"
+    return "EE"
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if not isinstance(arguments, dict):
+        return _error_response(f"arguments must be a dictionary, got {type(arguments)}")
+
+    errors: list[str] = []
+    for query in (GET_LICENSE_EDITION_QUERY, GET_LICENSE_EDITION_QUERY_CAMEL):
+        try:
+            result = await session.execute(gql(query))
+            settings = result.get("settings")
+            if not isinstance(settings, dict):
+                return _error_response("Unable to read settings from OpenCTI response")
+
+            source_field, raw_value = _extract_settings_value(settings)
+            if source_field == "unknown":
+                return _error_response(
+                    "Unable to determine license edition: enterprise edition field not found"
+                )
+
+            return _success_response(
+                {
+                    "edition": _edition_from_value(raw_value),
+                    "source_field": source_field,
+                    "raw_value": raw_value,
+                }
+            )
+        except Exception as error:  # noqa: BLE001
+            errors.append(str(error))
+
+    return _error_response(
+        "Unable to determine license edition from OpenCTI settings. "
+        f"Errors: {' | '.join(errors)}"
+    )

--- a/opencti_mcp/tools/list_case_rfis.py
+++ b/opencti_mcp/tools/list_case_rfis.py
@@ -1,0 +1,159 @@
+import re
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    success_response,
+)
+
+_ENUM_TOKEN_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CASE_RFI_LIST_ROOTS = (
+    ("caseRfis", "pirId"),
+    ("caseRfis", "casePirId"),
+    ("casesRfis", "pirId"),
+    ("casesRfis", "casePirId"),
+    ("casesRfi", "pirId"),
+    ("casesRfi", "casePirId"),
+    ("rfis", None),
+)
+
+
+def _normalize_enum_token(value: Any, field_name: str) -> tuple[str | None, str | None]:
+    normalized, normalize_error = normalize_non_empty_string(value, field_name)
+    if normalize_error:
+        return None, normalize_error
+    if normalized is None:
+        return None, None
+    if not _ENUM_TOKEN_PATTERN.fullmatch(normalized):
+        return None, (
+            f"{field_name} must be a valid GraphQL enum token "
+            "(letters, numbers and underscores only)"
+        )
+    return normalized, None
+
+
+def _build_list_query(
+    root_field: str,
+    pir_arg_name: str | None,
+    include_pir_filter: bool,
+    order_by: str | None = None,
+    order_mode: str | None = None,
+) -> str:
+    variable_declarations = [
+        "$search: String",
+        "$first: Int",
+        "$after: ID",
+    ]
+    args = [
+        "search: $search",
+        "first: $first",
+        "after: $after",
+    ]
+
+    if include_pir_filter and pir_arg_name:
+        variable_declarations.append("$pirId: String")
+        args.append(f"{pir_arg_name}: $pirId")
+
+    if order_by:
+        args.append(f"orderBy: {order_by}")
+    if order_mode:
+        args.append(f"orderMode: {order_mode}")
+
+    variables_block = ", ".join(variable_declarations)
+    args_block = "\n    ".join(args)
+    return f"""
+query ListCaseRfis({variables_block}) {{
+  result: {root_field}(
+    {args_block}
+  ) {{
+    edges {{
+      node {{
+        id
+        name
+        description
+      }}
+    }}
+    pageInfo {{
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }}
+  }}
+}}
+"""
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=50)
+    if first_error:
+        return error_response(first_error)
+    assert first is not None
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    pir_id, pir_id_error = normalize_non_empty_string(arguments.get("pir_id"), "pir_id")
+    if pir_id_error:
+        return error_response(pir_id_error)
+
+    order_by, order_by_error = _normalize_enum_token(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = _normalize_enum_token(arguments.get("orderMode"), "orderMode")
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    base_variables: dict[str, Any] = {
+        "search": search,
+        "first": first,
+        "after": after,
+    }
+
+    errors: list[str] = []
+    include_ordering_attempts = [True, False] if (order_by or order_mode) else [False]
+    include_pir_attempts = [True, False] if pir_id else [False]
+
+    for root_field, pir_arg_name in _CASE_RFI_LIST_ROOTS:
+        for include_pir_filter in include_pir_attempts:
+            if include_pir_filter and not pir_arg_name:
+                continue
+            for include_ordering in include_ordering_attempts:
+                query = _build_list_query(
+                    root_field=root_field,
+                    pir_arg_name=pir_arg_name,
+                    include_pir_filter=include_pir_filter,
+                    order_by=order_by if include_ordering else None,
+                    order_mode=order_mode if include_ordering else None,
+                )
+                variables = base_variables.copy()
+                if include_pir_filter:
+                    variables["pirId"] = pir_id
+                try:
+                    result = await session.execute(gql(query), variable_values=variables)
+                    return success_response(result.get("result", {}))
+                except Exception as error:  # noqa: BLE001
+                    errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to list case RFIs with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/list_identities.py
+++ b/opencti_mcp/tools/list_identities.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import LIST_IDENTITIES_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    types_value, types_error = normalize_string_list(arguments.get("types"), "types")
+    if types_error:
+        return error_response(types_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=50)
+    if first_error:
+        return error_response(first_error)
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = normalize_non_empty_string(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = normalize_non_empty_string(
+        arguments.get("orderMode"), "orderMode"
+    )
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables = {
+        "types": types_value,
+        "search": search,
+        "first": first,
+        "after": after,
+        "orderBy": order_by,
+        "orderMode": order_mode,
+    }
+
+    try:
+        result = await session.execute(gql(LIST_IDENTITIES_QUERY), variable_values=variables)
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("identities", {}))

--- a/opencti_mcp/tools/list_labels.py
+++ b/opencti_mcp/tools/list_labels.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import LIST_LABELS_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=100)
+    if first_error:
+        return error_response(first_error)
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = normalize_non_empty_string(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = normalize_non_empty_string(
+        arguments.get("orderMode"), "orderMode"
+    )
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables = {
+        "search": search,
+        "first": first,
+        "after": after,
+        "orderBy": order_by,
+        "orderMode": order_mode,
+    }
+
+    try:
+        result = await session.execute(gql(LIST_LABELS_QUERY), variable_values=variables)
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("labels", {}))

--- a/opencti_mcp/tools/list_marking_definitions.py
+++ b/opencti_mcp/tools/list_marking_definitions.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import LIST_MARKING_DEFINITIONS_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=100)
+    if first_error:
+        return error_response(first_error)
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = normalize_non_empty_string(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = normalize_non_empty_string(
+        arguments.get("orderMode"), "orderMode"
+    )
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables = {
+        "first": first,
+        "after": after,
+        "orderBy": order_by,
+        "orderMode": order_mode,
+    }
+
+    try:
+        result = await session.execute(
+            gql(LIST_MARKING_DEFINITIONS_QUERY),
+            variable_values=variables,
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("markingDefinitions", {}))

--- a/opencti_mcp/tools/list_pirs.py
+++ b/opencti_mcp/tools/list_pirs.py
@@ -1,0 +1,124 @@
+import re
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    success_response,
+)
+
+_ENUM_TOKEN_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PIR_LIST_ROOT_FIELDS = ("casePirs", "casesPirs", "casesPir", "pirs")
+
+
+def _normalize_enum_token(value: Any, field_name: str) -> tuple[str | None, str | None]:
+    normalized, normalize_error = normalize_non_empty_string(value, field_name)
+    if normalize_error:
+        return None, normalize_error
+    if normalized is None:
+        return None, None
+    if not _ENUM_TOKEN_PATTERN.fullmatch(normalized):
+        return None, (
+            f"{field_name} must be a valid GraphQL enum token "
+            "(letters, numbers and underscores only)"
+        )
+    return normalized, None
+
+
+def _build_list_query(
+    root_field: str,
+    order_by: str | None = None,
+    order_mode: str | None = None,
+) -> str:
+    args = [
+        "search: $search",
+        "first: $first",
+        "after: $after",
+    ]
+    if order_by:
+        args.append(f"orderBy: {order_by}")
+    if order_mode:
+        args.append(f"orderMode: {order_mode}")
+
+    args_block = "\n    ".join(args)
+    return f"""
+query ListPirs($search: String, $first: Int, $after: ID) {{
+  result: {root_field}(
+    {args_block}
+  ) {{
+    edges {{
+      node {{
+        id
+        name
+        description
+      }}
+    }}
+    pageInfo {{
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      globalCount
+    }}
+  }}
+}}
+"""
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=50)
+    if first_error:
+        return error_response(first_error)
+    assert first is not None
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = _normalize_enum_token(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = _normalize_enum_token(arguments.get("orderMode"), "orderMode")
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables: dict[str, Any] = {
+        "search": search,
+        "first": first,
+        "after": after,
+    }
+
+    errors: list[str] = []
+    include_ordering_attempts = [True, False] if (order_by or order_mode) else [False]
+    for root_field in _PIR_LIST_ROOT_FIELDS:
+        for include_ordering in include_ordering_attempts:
+            query = _build_list_query(
+                root_field=root_field,
+                order_by=order_by if include_ordering else None,
+                order_mode=order_mode if include_ordering else None,
+            )
+            try:
+                result = await session.execute(gql(query), variable_values=variables)
+                return success_response(result.get("result", {}))
+            except Exception as error:  # noqa: BLE001
+                errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to list PIRs with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/list_stix_core_objects.py
+++ b/opencti_mcp/tools/list_stix_core_objects.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import LIST_STIX_CORE_OBJECTS_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    types_value, types_error = normalize_string_list(arguments.get("types"), "types")
+    if types_error:
+        return error_response(types_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=50)
+    if first_error:
+        return error_response(first_error)
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = normalize_non_empty_string(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = normalize_non_empty_string(
+        arguments.get("orderMode"), "orderMode"
+    )
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables = {
+        "types": types_value,
+        "search": search,
+        "first": first,
+        "after": after,
+        "orderBy": order_by,
+        "orderMode": order_mode,
+    }
+
+    try:
+        result = await session.execute(
+            gql(LIST_STIX_CORE_OBJECTS_QUERY),
+            variable_values=variables,
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("stixCoreObjects", {}))

--- a/opencti_mcp/tools/list_stix_core_relationships.py
+++ b/opencti_mcp/tools/list_stix_core_relationships.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import LIST_STIX_CORE_RELATIONSHIPS_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_first,
+    normalize_non_empty_string,
+    normalize_string_list,
+    success_response,
+)
+
+
+def _normalize_list_or_string(value: Any, field_name: str) -> tuple[list[str] | None, str | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None, f"{field_name} cannot be an empty string"
+        return [cleaned], None
+    return normalize_string_list(value, field_name)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    from_or_to_id, from_or_to_id_error = _normalize_list_or_string(
+        arguments.get("from_or_to_ids"),
+        "from_or_to_ids",
+    )
+    if from_or_to_id_error:
+        return error_response(from_or_to_id_error)
+
+    from_id, from_id_error = _normalize_list_or_string(arguments.get("from_ids"), "from_ids")
+    if from_id_error:
+        return error_response(from_id_error)
+
+    to_id, to_id_error = _normalize_list_or_string(arguments.get("to_ids"), "to_ids")
+    if to_id_error:
+        return error_response(to_id_error)
+
+    relationship_type, relationship_type_error = _normalize_list_or_string(
+        arguments.get("relationship_types"),
+        "relationship_types",
+    )
+    if relationship_type_error:
+        return error_response(relationship_type_error)
+
+    search, search_error = normalize_non_empty_string(arguments.get("search"), "search")
+    if search_error:
+        return error_response(search_error)
+
+    first, first_error = normalize_first(arguments.get("first"), default=100)
+    if first_error:
+        return error_response(first_error)
+
+    after, after_error = normalize_non_empty_string(arguments.get("after"), "after")
+    if after_error:
+        return error_response(after_error)
+
+    order_by, order_by_error = normalize_non_empty_string(arguments.get("orderBy"), "orderBy")
+    if order_by_error:
+        return error_response(order_by_error)
+
+    order_mode, order_mode_error = normalize_non_empty_string(
+        arguments.get("orderMode"), "orderMode"
+    )
+    if order_mode_error:
+        return error_response(order_mode_error)
+
+    variables = {
+        "fromOrToId": from_or_to_id,
+        "fromId": from_id,
+        "toId": to_id,
+        "relationship_type": relationship_type,
+        "search": search,
+        "first": first,
+        "after": after,
+        "orderBy": order_by,
+        "orderMode": order_mode,
+    }
+
+    try:
+        result = await session.execute(
+            gql(LIST_STIX_CORE_RELATIONSHIPS_QUERY),
+            variable_values=variables,
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("stixCoreRelationships", {}))

--- a/opencti_mcp/tools/read_case_rfi.py
+++ b/opencti_mcp/tools/read_case_rfi.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+_CASE_RFI_READ_ROOT_FIELDS = ("caseRfi", "rfi")
+
+
+def _build_read_query(root_field: str) -> str:
+    return f"""
+query ReadCaseRfi($id: String!) {{
+  result: {root_field}(id: $id) {{
+    id
+    name
+    description
+  }}
+}}
+"""
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    case_rfi_id, case_rfi_id_error = normalize_non_empty_string(
+        arguments.get("id"),
+        "id",
+        required=True,
+    )
+    if case_rfi_id_error:
+        return error_response(case_rfi_id_error)
+    assert case_rfi_id is not None
+
+    errors: list[str] = []
+    variables = {"id": case_rfi_id}
+    for root_field in _CASE_RFI_READ_ROOT_FIELDS:
+        try:
+            result = await session.execute(
+                gql(_build_read_query(root_field)),
+                variable_values=variables,
+            )
+            return success_response(result.get("result"))
+        except Exception as error:  # noqa: BLE001
+            errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to read case RFI with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/read_identity.py
+++ b/opencti_mcp/tools/read_identity.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import READ_IDENTITY_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    identity_id, id_error = normalize_non_empty_string(arguments.get("id"), "id", required=True)
+    if id_error:
+        return error_response(id_error)
+    assert identity_id is not None
+
+    try:
+        result = await session.execute(
+            gql(READ_IDENTITY_QUERY),
+            variable_values={"id": identity_id},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("identity", {}))

--- a/opencti_mcp/tools/read_label.py
+++ b/opencti_mcp/tools/read_label.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import READ_LABEL_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    label_id, label_id_error = normalize_non_empty_string(arguments.get("id"), "id", required=True)
+    if label_id_error:
+        return error_response(label_id_error)
+    assert label_id is not None
+
+    try:
+        result = await session.execute(gql(READ_LABEL_QUERY), variable_values={"id": label_id})
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("label", {}))

--- a/opencti_mcp/tools/read_marking_definition.py
+++ b/opencti_mcp/tools/read_marking_definition.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import READ_MARKING_DEFINITION_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    marking_id, marking_id_error = normalize_non_empty_string(
+        arguments.get("id"),
+        "id",
+        required=True,
+    )
+    if marking_id_error:
+        return error_response(marking_id_error)
+    assert marking_id is not None
+
+    try:
+        result = await session.execute(
+            gql(READ_MARKING_DEFINITION_QUERY),
+            variable_values={"id": marking_id},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("markingDefinition", {}))

--- a/opencti_mcp/tools/read_pir.py
+++ b/opencti_mcp/tools/read_pir.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+_PIR_READ_ROOT_FIELDS = ("casePir", "pir")
+
+
+def _build_read_query(root_field: str) -> str:
+    return f"""
+query ReadPir($id: String!) {{
+  result: {root_field}(id: $id) {{
+    id
+    name
+    description
+  }}
+}}
+"""
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    pir_id, pir_id_error = normalize_non_empty_string(arguments.get("id"), "id", required=True)
+    if pir_id_error:
+        return error_response(pir_id_error)
+    assert pir_id is not None
+
+    errors: list[str] = []
+    variables = {"id": pir_id}
+    for root_field in _PIR_READ_ROOT_FIELDS:
+        try:
+            result = await session.execute(
+                gql(_build_read_query(root_field)),
+                variable_values=variables,
+            )
+            return success_response(result.get("result"))
+        except Exception as error:  # noqa: BLE001
+            errors.append(str(error))
+
+    last_error = errors[-1] if errors else "unknown schema mismatch"
+    return error_response(
+        "Unable to read PIR with the available GraphQL schema variants. "
+        f"Last error: {last_error}"
+    )

--- a/opencti_mcp/tools/read_stix_core_object.py
+++ b/opencti_mcp/tools/read_stix_core_object.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import READ_STIX_CORE_OBJECT_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    object_id, object_id_error = normalize_non_empty_string(
+        arguments.get("id"),
+        "id",
+        required=True,
+    )
+    if object_id_error:
+        return error_response(object_id_error)
+    assert object_id is not None
+
+    try:
+        result = await session.execute(
+            gql(READ_STIX_CORE_OBJECT_QUERY),
+            variable_values={"id": object_id},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("stixCoreObject", {}))

--- a/opencti_mcp/tools/read_stix_core_relationship.py
+++ b/opencti_mcp/tools/read_stix_core_relationship.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from gql import gql
+from mcp import types as mcp_types
+
+from opencti_mcp.graphql_queries import READ_STIX_CORE_RELATIONSHIP_QUERY
+from opencti_mcp.tools.tool_helpers import (
+    ensure_arguments_dict,
+    error_response,
+    normalize_non_empty_string,
+    success_response,
+)
+
+
+async def handle(session: Any, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    args_error = ensure_arguments_dict(arguments)
+    if args_error:
+        return error_response(args_error)
+
+    relationship_id, relationship_id_error = normalize_non_empty_string(
+        arguments.get("id"),
+        "id",
+        required=True,
+    )
+    if relationship_id_error:
+        return error_response(relationship_id_error)
+    assert relationship_id is not None
+
+    try:
+        result = await session.execute(
+            gql(READ_STIX_CORE_RELATIONSHIP_QUERY),
+            variable_values={"id": relationship_id},
+        )
+    except Exception as error:  # noqa: BLE001
+        return error_response(str(error))
+
+    return success_response(result.get("stixCoreRelationship", {}))

--- a/opencti_mcp/tools/tool_helpers.py
+++ b/opencti_mcp/tools/tool_helpers.py
@@ -1,0 +1,89 @@
+import json
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+def error_response(message: str) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": False, "error": message}, indent=2),
+        )
+    ]
+
+
+def success_response(data: Any) -> list[mcp_types.TextContent]:
+    return [
+        mcp_types.TextContent(
+            type="text",
+            text=json.dumps({"success": True, "data": data}, indent=2),
+        )
+    ]
+
+
+def ensure_arguments_dict(arguments: Any) -> str | None:
+    if isinstance(arguments, dict):
+        return None
+    return f"arguments must be a dictionary, got {type(arguments)}"
+
+
+def normalize_non_empty_string(
+    value: Any, field_name: str, *, required: bool = False
+) -> tuple[str | None, str | None]:
+    if value is None:
+        if required:
+            return None, f"{field_name} is required"
+        return None, None
+    if not isinstance(value, str):
+        return None, f"{field_name} must be a string"
+    cleaned = value.strip()
+    if required and not cleaned:
+        return None, f"{field_name} is required and cannot be empty"
+    if not required and not cleaned:
+        return None, None
+    return cleaned, None
+
+
+def normalize_string_list(
+    value: Any, field_name: str, *, required: bool = False
+) -> tuple[list[str] | None, str | None]:
+    if value is None:
+        if required:
+            return None, f"{field_name} is required"
+        return None, None
+    if not isinstance(value, list):
+        return None, f"{field_name} must be a list of strings"
+
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None, f"{field_name} must only contain strings"
+        cleaned = item.strip()
+        if not cleaned:
+            return None, f"{field_name} cannot contain empty strings"
+        normalized.append(cleaned)
+
+    if required and not normalized:
+        return None, f"{field_name} cannot be empty"
+    return normalized, None
+
+
+def normalize_first(value: Any, default: int = 50) -> tuple[int | None, str | None]:
+    if value is None:
+        return default, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, "first must be an integer between 1 and 500"
+    if value < 1 or value > 500:
+        return None, "first must be an integer between 1 and 500"
+    return value, None
+
+
+def normalize_confidence(value: Any, default: int = 80) -> tuple[int | None, str | None]:
+    if value is None:
+        return default, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, "confidence must be an integer between 0 and 100"
+    if value < 0 or value > 100:
+        return None, "confidence must be an integer between 0 and 100"
+    return value, None

--- a/opencti_mcp/utils/mutations.py
+++ b/opencti_mcp/utils/mutations.py
@@ -1,0 +1,10 @@
+"""Helpers for write-operation gating."""
+
+import os
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def mutations_enabled() -> bool:
+    raw_value = os.getenv("OPENCTI_ENABLE_MUTATIONS", "").strip().lower()
+    return raw_value in _TRUE_VALUES

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,18 @@ EXPECTED_TOOL_NAMES: set[str] = {
     "read_marking_definition",
     "list_labels",
     "read_label",
+    "list_pirs",
+    "read_pir",
+    "list_case_rfis",
+    "read_case_rfi",
     "search_entities_by_name",
     "create_identity",
     "create_grouping",
     "create_external_reference",
     "create_label",
+    "create_pir",
+    "create_case_rfi",
+    "add_objects_to_case_rfi",
     "create_report",
     "add_note",
     "create_relationship",
@@ -228,6 +235,41 @@ def _register_tools(server: FastMCP) -> None:
         """Read one label by ID."""
         return await _echo_via_context(ctx)
 
+    @server.tool(name="list_pirs")
+    async def list_pirs(
+        ctx: Context,
+        search: str | None = None,
+        first: int = 50,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List PIRs with optional filters."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_pir")
+    async def read_pir(ctx: Context, id: str) -> list[mcp_types.TextContent]:  # noqa: A002
+        """Read one PIR by ID."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_case_rfis")
+    async def list_case_rfis(
+        ctx: Context,
+        search: str | None = None,
+        first: int = 50,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+        pir_id: str | None = None,
+    ) -> list[mcp_types.TextContent]:
+        """List case RFIs with optional filters."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_case_rfi")
+    async def read_case_rfi(ctx: Context, id: str) -> list[mcp_types.TextContent]:  # noqa: A002
+        """Read one case RFI by ID."""
+        return await _echo_via_context(ctx)
+
     @server.tool(name="execute_graphql_query")
     async def execute_graphql_query(ctx: Context, query: str) -> list[mcp_types.TextContent]:
         """Execute a GraphQL query and return the result."""
@@ -353,6 +395,51 @@ def _register_tools(server: FastMCP) -> None:
         update: bool = False,
     ) -> list[mcp_types.TextContent]:
         """Create a label."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_pir")
+    async def create_pir(
+        ctx: Context,
+        name: str,
+        description: str | None = None,
+        content: str | None = None,
+        priority: str | None = None,
+        severity: str | None = None,
+        confidence: int = 80,
+        object_marking: list[str] | None = None,
+        object_label: list[str] | None = None,
+        external_references: list[str] | None = None,
+        objects: list[str] | None = None,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create a PIR."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_case_rfi")
+    async def create_case_rfi(
+        ctx: Context,
+        name: str,
+        description: str | None = None,
+        content: str | None = None,
+        severity: str | None = None,
+        pir_id: str | None = None,
+        confidence: int = 80,
+        object_marking: list[str] | None = None,
+        object_label: list[str] | None = None,
+        external_references: list[str] | None = None,
+        objects: list[str] | None = None,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create a case RFI."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="add_objects_to_case_rfi")
+    async def add_objects_to_case_rfi(
+        ctx: Context,
+        id: str,  # noqa: A002
+        object_ids: list[str],
+    ) -> list[mcp_types.TextContent]:
+        """Add objects to a case RFI."""
         return await _echo_via_context(ctx)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,25 @@ EXPECTED_TOOL_NAMES: set[str] = {
     "get_stix_relationships_mapping",
     "get_query_fields",
     "get_entity_names",
+    "get_license_edition",
+    "list_identities",
+    "read_identity",
+    "list_stix_core_objects",
+    "read_stix_core_object",
+    "list_stix_core_relationships",
+    "read_stix_core_relationship",
+    "list_marking_definitions",
+    "read_marking_definition",
+    "list_labels",
+    "read_label",
     "search_entities_by_name",
+    "create_identity",
+    "create_grouping",
+    "create_external_reference",
+    "create_label",
+    "create_report",
+    "add_note",
+    "create_relationship",
 }
 
 
@@ -106,6 +124,110 @@ def _register_tools(server: FastMCP) -> None:
         """Get all unique entity names from STIX relationships mapping."""
         return await _echo_via_context(ctx)
 
+    @server.tool(name="get_license_edition")
+    async def get_license_edition(ctx: Context) -> list[mcp_types.TextContent]:
+        """Detect whether the target OpenCTI is CE or EE."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_identities")
+    async def list_identities(
+        ctx: Context,
+        types: list[str] | None = None,
+        search: str | None = None,
+        first: int = 50,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List identities with optional filters."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_identity")
+    async def read_identity(ctx: Context, id: str) -> list[mcp_types.TextContent]:  # noqa: A002
+        """Read one identity by ID."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_stix_core_objects")
+    async def list_stix_core_objects(
+        ctx: Context,
+        types: list[str] | None = None,
+        search: str | None = None,
+        first: int = 50,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List STIX core objects with optional filters."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_stix_core_object")
+    async def read_stix_core_object(
+        ctx: Context,
+        id: str,  # noqa: A002
+    ) -> list[mcp_types.TextContent]:
+        """Read one STIX core object by ID."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_stix_core_relationships")
+    async def list_stix_core_relationships(
+        ctx: Context,
+        from_or_to_ids: list[str] | None = None,
+        from_ids: list[str] | None = None,
+        to_ids: list[str] | None = None,
+        relationship_types: list[str] | None = None,
+        search: str | None = None,
+        first: int = 100,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List STIX core relationships with optional filters."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_stix_core_relationship")
+    async def read_stix_core_relationship(
+        ctx: Context,
+        id: str,  # noqa: A002
+    ) -> list[mcp_types.TextContent]:
+        """Read one STIX core relationship by ID."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_marking_definitions")
+    async def list_marking_definitions(
+        ctx: Context,
+        first: int = 100,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List marking definitions."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_marking_definition")
+    async def read_marking_definition(
+        ctx: Context,
+        id: str,  # noqa: A002
+    ) -> list[mcp_types.TextContent]:
+        """Read one marking definition by ID."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="list_labels")
+    async def list_labels(
+        ctx: Context,
+        search: str | None = None,
+        first: int = 100,
+        after: str | None = None,
+        orderBy: str | None = None,  # noqa: N803
+        orderMode: str | None = None,  # noqa: N803
+    ) -> list[mcp_types.TextContent]:
+        """List labels."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="read_label")
+    async def read_label(ctx: Context, id: str) -> list[mcp_types.TextContent]:  # noqa: A002
+        """Read one label by ID."""
+        return await _echo_via_context(ctx)
+
     @server.tool(name="execute_graphql_query")
     async def execute_graphql_query(ctx: Context, query: str) -> list[mcp_types.TextContent]:
         """Execute a GraphQL query and return the result."""
@@ -138,6 +260,99 @@ def _register_tools(server: FastMCP) -> None:
         entity_name: str,
     ) -> list[mcp_types.TextContent]:
         """Search for entities by name and intersect with available entity types."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_report")
+    async def create_report(
+        ctx: Context,
+        name: str,
+        description: str,
+        report_types: list[str] | None = None,
+        published: str | None = None,
+        confidence: int = 80,
+        objects: list[str] | None = None,
+        labels: list[str] | None = None,
+    ) -> list[mcp_types.TextContent]:
+        """Create a report in OpenCTI."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="add_note")
+    async def add_note(
+        ctx: Context,
+        content: str,
+        objects: list[str],
+        attribute_abstract: str | None = None,
+        note_types: list[str] | None = None,
+        confidence: int = 80,
+    ) -> list[mcp_types.TextContent]:
+        """Add a note to entities in OpenCTI."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_relationship")
+    async def create_relationship(
+        ctx: Context,
+        fromId: str,  # noqa: N803
+        toId: str,  # noqa: N803
+        relationship_type: str,
+    ) -> list[mcp_types.TextContent]:
+        """Create a relationship between entities in OpenCTI."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_identity")
+    async def create_identity(
+        ctx: Context,
+        name: str,
+        type: str = "Organization",  # noqa: A002
+        description: str | None = None,
+        contact_information: str | None = None,
+        confidence: int = 80,
+        object_marking: list[str] | None = None,
+        object_label: list[str] | None = None,
+        external_references: list[str] | None = None,
+        x_opencti_organization_type: str | None = None,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create an identity."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_grouping")
+    async def create_grouping(
+        ctx: Context,
+        name: str,
+        context: str,
+        description: str | None = None,
+        content: str | None = None,
+        objects: list[str] | None = None,
+        object_marking: list[str] | None = None,
+        object_label: list[str] | None = None,
+        external_references: list[str] | None = None,
+        confidence: int = 80,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create a grouping."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_external_reference")
+    async def create_external_reference(
+        ctx: Context,
+        source_name: str | None = None,
+        url: str | None = None,
+        description: str | None = None,
+        external_id: str | None = None,
+        x_opencti_stix_ids: list[str] | None = None,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create an external reference."""
+        return await _echo_via_context(ctx)
+
+    @server.tool(name="create_label")
+    async def create_label(
+        ctx: Context,
+        value: str,
+        color: str | None = None,
+        update: bool = False,
+    ) -> list[mcp_types.TextContent]:
+        """Create a label."""
         return await _echo_via_context(ctx)
 
 

--- a/tests/test_brand_posture_pack_tools.py
+++ b/tests/test_brand_posture_pack_tools.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from opencti_mcp.tools import create_external_reference as create_external_reference_tool
+from opencti_mcp.tools import create_identity as create_identity_tool
+from opencti_mcp.tools import list_stix_core_objects as list_stix_core_objects_tool
+
+
+async def test_list_stix_core_objects_executes_with_types_and_search():
+    session = AsyncMock()
+    session.execute.return_value = {"stixCoreObjects": {"edges": [{"node": {"id": "report--1"}}]}}
+
+    result = await list_stix_core_objects_tool.handle(
+        session,
+        {
+            "types": ["Report", "Campaign"],
+            "search": "brand",
+            "first": 25,
+        },
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["edges"][0]["node"]["id"] == "report--1"
+    assert session.execute.await_args.kwargs["variable_values"]["types"] == ["Report", "Campaign"]
+    assert session.execute.await_args.kwargs["variable_values"]["search"] == "brand"
+    assert session.execute.await_args.kwargs["variable_values"]["first"] == 25
+
+
+async def test_create_identity_uses_organization_add_for_organization(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"organizationAdd": {"id": "identity--1", "name": "Acme"}}
+
+    result = await create_identity_tool.handle(
+        session,
+        {"name": "Acme", "type": "Organization"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["id"] == "identity--1"
+    assert session.execute.await_args.kwargs["variable_values"]["input"]["name"] == "Acme"
+
+
+async def test_create_identity_uses_identity_add_for_non_organization(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"identityAdd": {"id": "identity--2", "name": "Analyst User"}}
+
+    result = await create_identity_tool.handle(
+        session,
+        {"name": "Analyst User", "type": "Individual"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["id"] == "identity--2"
+    assert session.execute.await_args.kwargs["variable_values"]["input"]["type"] == "Individual"
+
+
+async def test_create_external_reference_requires_source_or_url(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+
+    result = await create_external_reference_tool.handle(session, {})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "source_name or url is required" in payload["error"]
+    session.execute.assert_not_called()

--- a/tests/test_execute_graphql_query_tool.py
+++ b/tests/test_execute_graphql_query_tool.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from opencti_mcp.tools import execute_graphql_query as execute_graphql_query_tool
+
+
+async def test_execute_graphql_query_prefixes_query_when_no_operation(monkeypatch):
+    monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    session = AsyncMock()
+    session.execute.return_value = {"viewer": {"id": "user--1"}}
+
+    result = await execute_graphql_query_tool.handle(session, {"query": "{ viewer { id } }"})
+
+    payload = json.loads(result[0].text)
+    assert payload == {"success": True, "data": {"viewer": {"id": "user--1"}}}
+    assert session.execute.await_count == 1
+    sent_query = session.execute.await_args.args[0]
+    assert sent_query.startswith("query ")
+
+
+async def test_execute_graphql_query_accepts_mutation_without_forcing_query(monkeypatch):
+    monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    session = AsyncMock()
+    session.execute.return_value = {"result": {"id": "x"}}
+
+    result = await execute_graphql_query_tool.handle(
+        session,
+        {"query": "mutation DoThing { ping }"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert session.execute.await_count == 1
+    sent_query = session.execute.await_args.args[0]
+    assert sent_query.startswith("mutation ")
+    assert not sent_query.startswith("query mutation ")
+
+
+async def test_execute_graphql_query_returns_json_error_for_invalid_arguments():
+    session = AsyncMock()
+
+    result = await execute_graphql_query_tool.handle(session, {"query": ""})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "query" in payload["error"]
+    session.execute.assert_not_called()

--- a/tests/test_execute_graphql_query_tool.py
+++ b/tests/test_execute_graphql_query_tool.py
@@ -22,6 +22,7 @@ async def test_execute_graphql_query_prefixes_query_when_no_operation(monkeypatc
 
 async def test_execute_graphql_query_accepts_mutation_without_forcing_query(monkeypatch):
     monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
     session = AsyncMock()
     session.execute.return_value = {"result": {"id": "x"}}
 
@@ -36,6 +37,58 @@ async def test_execute_graphql_query_accepts_mutation_without_forcing_query(monk
     sent_query = session.execute.await_args.args[0]
     assert sent_query.startswith("mutation ")
     assert not sent_query.startswith("query mutation ")
+
+
+async def test_execute_graphql_query_blocks_mutation_when_mutations_disabled(monkeypatch):
+    monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "false")
+    session = AsyncMock()
+
+    result = await execute_graphql_query_tool.handle(
+        session,
+        {"query": "mutation DoThing { ping }"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
+
+
+async def test_execute_graphql_query_keeps_fragment_led_document_untouched(monkeypatch):
+    monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    session = AsyncMock()
+    session.execute.return_value = {"viewer": {"id": "user--1"}}
+
+    fragment_doc = (
+        "fragment ViewerFields on Query { viewer { id } }\n"
+        "query ViewerQuery { viewer { id } }"
+    )
+    result = await execute_graphql_query_tool.handle(session, {"query": fragment_doc})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert session.execute.await_count == 1
+    sent_query = session.execute.await_args.args[0]
+    assert sent_query.startswith("fragment ")
+    assert not sent_query.startswith("query fragment ")
+
+
+async def test_execute_graphql_query_blocks_fragment_led_mutation_when_disabled(monkeypatch):
+    monkeypatch.setattr(execute_graphql_query_tool, "gql", lambda query: query)
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "false")
+    session = AsyncMock()
+
+    fragment_mutation_doc = (
+        "fragment ViewerFields on Query { viewer { id } }\n"
+        "mutation DoThing { ping }"
+    )
+    result = await execute_graphql_query_tool.handle(session, {"query": fragment_mutation_doc})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
 
 
 async def test_execute_graphql_query_returns_json_error_for_invalid_arguments():

--- a/tests/test_get_license_edition_tool.py
+++ b/tests/test_get_license_edition_tool.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from opencti_mcp.tools import get_license_edition as get_license_edition_tool
+
+
+async def test_get_license_edition_reports_ee_when_value_present():
+    session = AsyncMock()
+    session.execute.return_value = {"settings": {"enterprise_edition": "2026-01-15T00:00:00.000Z"}}
+
+    result = await get_license_edition_tool.handle(session, {})
+    payload = json.loads(result[0].text)
+
+    assert payload["success"] is True
+    assert payload["data"]["edition"] == "EE"
+    assert payload["data"]["source_field"] == "enterprise_edition"
+
+
+async def test_get_license_edition_reports_ce_when_value_is_null():
+    session = AsyncMock()
+    session.execute.return_value = {"settings": {"enterprise_edition": None}}
+
+    result = await get_license_edition_tool.handle(session, {})
+    payload = json.loads(result[0].text)
+
+    assert payload["success"] is True
+    assert payload["data"]["edition"] == "CE"
+    assert payload["data"]["source_field"] == "enterprise_edition"
+
+
+async def test_get_license_edition_uses_camel_case_fallback():
+    session = AsyncMock()
+    session.execute.side_effect = [
+        Exception("Cannot query field 'enterprise_edition' on type 'Settings'."),
+        {"settings": {"enterpriseEdition": "2026-01-15T00:00:00.000Z"}},
+    ]
+
+    result = await get_license_edition_tool.handle(session, {})
+    payload = json.loads(result[0].text)
+
+    assert payload["success"] is True
+    assert payload["data"]["edition"] == "EE"
+    assert payload["data"]["source_field"] == "enterpriseEdition"
+    assert session.execute.await_count == 2
+
+
+async def test_get_license_edition_returns_error_when_both_queries_fail():
+    session = AsyncMock()
+    session.execute.side_effect = [
+        Exception("field enterprise_edition not found"),
+        Exception("field enterpriseEdition not found"),
+    ]
+
+    result = await get_license_edition_tool.handle(session, {})
+    payload = json.loads(result[0].text)
+
+    assert payload["success"] is False
+    assert "Unable to determine license edition" in payload["error"]

--- a/tests/test_mutation_tools.py
+++ b/tests/test_mutation_tools.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from opencti_mcp.tools import add_note as add_note_tool
+from opencti_mcp.tools import create_relationship as create_relationship_tool
+from opencti_mcp.tools import create_report as create_report_tool
+
+
+async def test_create_report_is_blocked_when_mutations_disabled(monkeypatch):
+    monkeypatch.delenv("OPENCTI_ENABLE_MUTATIONS", raising=False)
+    session = AsyncMock()
+
+    result = await create_report_tool.handle(
+        session,
+        {"name": "Report A", "description": "Body"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
+
+
+async def test_create_report_executes_with_expected_payload(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"reportAdd": {"id": "report--1", "name": "Report A"}}
+
+    result = await create_report_tool.handle(
+        session,
+        {
+            "name": "Report A",
+            "description": "Body",
+            "report_types": ["threat-report"],
+            "published": "2026-02-24T00:00:00.000Z",
+            "confidence": 90,
+            "objects": ["indicator--1"],
+            "labels": ["malware"],
+        },
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload == {"success": True, "data": {"id": "report--1", "name": "Report A"}}
+
+    assert session.execute.await_count == 1
+    assert session.execute.await_args.kwargs["variable_values"] == {
+        "input": {
+            "name": "Report A",
+            "description": "Body",
+            "report_types": ["threat-report"],
+            "published": "2026-02-24T00:00:00.000Z",
+            "confidence": 90,
+            "objects": ["indicator--1"],
+            "objectLabel": ["malware"],
+        }
+    }
+
+
+async def test_add_note_requires_objects(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+
+    result = await add_note_tool.handle(
+        session,
+        {"content": "Note body"},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "objects" in payload["error"]
+    session.execute.assert_not_called()
+
+
+async def test_create_relationship_executes_with_expected_payload(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {
+        "stixCoreRelationshipAdd": {
+            "id": "relationship--1",
+            "relationship_type": "related-to",
+        }
+    }
+
+    result = await create_relationship_tool.handle(
+        session,
+        {
+            "fromId": "indicator--1",
+            "toId": "malware--1",
+            "relationship_type": "related-to",
+        },
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["id"] == "relationship--1"
+
+    assert session.execute.await_count == 1
+    assert session.execute.await_args.kwargs["variable_values"] == {
+        "input": {
+            "fromId": "indicator--1",
+            "toId": "malware--1",
+            "relationship_type": "related-to",
+        }
+    }

--- a/tests/test_pir_case_rfi_tools.py
+++ b/tests/test_pir_case_rfi_tools.py
@@ -51,13 +51,18 @@ async def test_add_objects_to_case_rfi_is_blocked_when_mutations_disabled(monkey
 async def test_create_pir_executes_when_mutations_enabled(monkeypatch):
     monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
     session = AsyncMock()
-    session.execute.return_value = {"result": {"id": "pir--1", "name": "PIR A"}}
+    session.execute.return_value = {"pirAdd": {"id": "pir--1", "name": "PIR A"}}
 
     result = await create_pir_tool.handle(session, {"name": "PIR A", "description": "Desc"})
 
     payload = json.loads(result[0].text)
     assert payload == {"success": True, "data": {"id": "pir--1", "name": "PIR A"}}
-    assert session.execute.await_count >= 1
+    assert session.execute.await_count == 1
+    sent_input = session.execute.await_args.kwargs["variable_values"]["input"]
+    assert sent_input["name"] == "PIR A"
+    assert sent_input["pir_type"] == "THREAT_CUSTOM"
+    assert sent_input["pir_rescan_days"] == 30
+    assert sent_input["pir_criteria"][0]["weight"] == 1
 
 
 async def test_create_case_rfi_executes_when_mutations_enabled(monkeypatch):

--- a/tests/test_pir_case_rfi_tools.py
+++ b/tests/test_pir_case_rfi_tools.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from opencti_mcp.tools import add_objects_to_case_rfi as add_objects_to_case_rfi_tool
+from opencti_mcp.tools import create_case_rfi as create_case_rfi_tool
+from opencti_mcp.tools import create_pir as create_pir_tool
+from opencti_mcp.tools import list_pirs as list_pirs_tool
+
+
+async def test_create_pir_is_blocked_when_mutations_disabled(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "false")
+    session = AsyncMock()
+
+    result = await create_pir_tool.handle(session, {"name": "PIR A"})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
+
+
+async def test_create_case_rfi_is_blocked_when_mutations_disabled(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "false")
+    session = AsyncMock()
+
+    result = await create_case_rfi_tool.handle(session, {"name": "RFI A"})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
+
+
+async def test_add_objects_to_case_rfi_is_blocked_when_mutations_disabled(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "false")
+    session = AsyncMock()
+
+    result = await add_objects_to_case_rfi_tool.handle(
+        session,
+        {"id": "case-rfi--1", "object_ids": ["indicator--1"]},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "disabled" in payload["error"].lower()
+    session.execute.assert_not_called()
+
+
+async def test_create_pir_executes_when_mutations_enabled(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"result": {"id": "pir--1", "name": "PIR A"}}
+
+    result = await create_pir_tool.handle(session, {"name": "PIR A", "description": "Desc"})
+
+    payload = json.loads(result[0].text)
+    assert payload == {"success": True, "data": {"id": "pir--1", "name": "PIR A"}}
+    assert session.execute.await_count >= 1
+
+
+async def test_create_case_rfi_executes_when_mutations_enabled(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"result": {"id": "case-rfi--1", "name": "RFI A"}}
+
+    result = await create_case_rfi_tool.handle(session, {"name": "RFI A"})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["id"] == "case-rfi--1"
+    assert session.execute.await_count >= 1
+
+
+async def test_add_objects_to_case_rfi_deduplicates_and_executes(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+    session.execute.return_value = {"result": {"id": "relation--1"}}
+
+    result = await add_objects_to_case_rfi_tool.handle(
+        session,
+        {"id": "case-rfi--1", "object_ids": ["indicator--1", "malware--1", "indicator--1"]},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["data"]["case_rfi_id"] == "case-rfi--1"
+    assert payload["data"]["added_object_ids"] == ["indicator--1", "malware--1"]
+    assert session.execute.await_count == 2
+
+
+async def test_add_objects_to_case_rfi_requires_non_empty_list(monkeypatch):
+    monkeypatch.setenv("OPENCTI_ENABLE_MUTATIONS", "true")
+    session = AsyncMock()
+
+    result = await add_objects_to_case_rfi_tool.handle(
+        session,
+        {"id": "case-rfi--1", "object_ids": []},
+    )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "object_ids" in payload["error"]
+    session.execute.assert_not_called()
+
+
+async def test_list_pirs_validates_first_range():
+    session = AsyncMock()
+
+    result = await list_pirs_tool.handle(session, {"first": 0})
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "first" in payload["error"]
+    session.execute.assert_not_called()

--- a/tests/test_transport_memory.py
+++ b/tests/test_transport_memory.py
@@ -19,7 +19,7 @@ async def test_initialize(test_server):
 
 
 async def test_list_tools_returns_all_expected_names(test_server):
-    """list_tools() returns exactly the 9 registered tools."""
+    """list_tools() returns exactly the registered tools."""
     async with create_connected_server_and_client_session(test_server) as session:
         result = await session.list_tools()
         tool_names = {t.name for t in result.tools}


### PR DESCRIPTION
- add read tools for identities, STIX core objects/relationships, labels and markings

- add write tools for identity/label/external reference/grouping plus report/note/relationship

- add EE/CE license edition detection tool

- keep mutations safe-by-default via --enable-mutations or OPENCTI_ENABLE_MUTATIONS

- add GraphQL queries/mutations and shared tool helpers

- update transport test registry and add unit tests for mutation/license/brand pack tools

- overhaul root and opencti_mcp README documentation